### PR TITLE
Add line numbers to error output.

### DIFF
--- a/src/com/ModDamage/Alias/Aliaser.java
+++ b/src/com/ModDamage/Alias/Aliaser.java
@@ -193,7 +193,7 @@ abstract public class Aliaser<Type, StoredInfoClass> implements ScriptLineHandle
 				@Override
 				public ScriptLineHandler handleLine(ScriptLine line, boolean hasChildren)
 				{
-					Collection<InfoType> subvalues = matchAlias(line.line);
+					Collection<InfoType> subvalues = matchAlias(line);
 					if (subvalues != null)
 						values.addAll(subvalues);
 					else {
@@ -278,7 +278,11 @@ abstract public class Aliaser<Type, StoredInfoClass> implements ScriptLineHandle
 //		}
 		
 		//@Override
-		public Collection<InfoType> matchAlias(String key)
+		public Collection<InfoType> matchAlias(ScriptLine scriptLine) {
+			return matchAlias(scriptLine, scriptLine.line);
+		}
+		
+		public Collection<InfoType> matchAlias(ScriptLine scriptLine, String key)
 		{
 			if(hasAlias(key))
 				return getAlias(key);
@@ -296,7 +300,7 @@ abstract public class Aliaser<Type, StoredInfoClass> implements ScriptLineHandle
 				}
 			}
 			if(!failFlag && !values.isEmpty()) return values;
-			LogUtil.error("No matching " + name + " alias or value \"" + key + "\"");
+			LogUtil.error(scriptLine, "No matching " + name + " alias or value \"" + key + "\"");
 			return getDefaultValue();
 		}
 

--- a/src/com/ModDamage/Alias/ArmorAliaser.java
+++ b/src/com/ModDamage/Alias/ArmorAliaser.java
@@ -4,11 +4,13 @@ import java.util.Collection;
 
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
 import com.ModDamage.Backend.ArmorSet;
+import com.ModDamage.Backend.ScriptLine;
 
 public class ArmorAliaser extends CollectionAliaser<ArmorSet> 
 {
 	public static ArmorAliaser aliaser = new ArmorAliaser();
-	public static Collection<ArmorSet> match(String string) { return aliaser.matchAlias(string); }
+	public static Collection<ArmorSet> match(ScriptLine scriptLine, String string) { return aliaser.matchAlias(scriptLine, string); }
+	public static Collection<ArmorSet> match(ScriptLine scriptLine) { return aliaser.matchAlias(scriptLine); }
 	
 	public ArmorAliaser(){ super(AliasManager.Armor.name()); }
 	@Override

--- a/src/com/ModDamage/Alias/BiomeAliaser.java
+++ b/src/com/ModDamage/Alias/BiomeAliaser.java
@@ -5,11 +5,13 @@ import java.util.Collection;
 import org.bukkit.block.Biome;
 
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
+import com.ModDamage.Backend.ScriptLine;
 
 public class BiomeAliaser extends CollectionAliaser<Biome> 
 {
 	public static BiomeAliaser aliaser = new BiomeAliaser();
-	public static Collection<Biome> match(String string) { return aliaser.matchAlias(string); }
+	public static Collection<Biome> match(ScriptLine scriptLine) { return aliaser.matchAlias(scriptLine); }
+	public static Collection<Biome> match(ScriptLine scriptLine, String key) { return aliaser.matchAlias(scriptLine, key); }
 	
 	public BiomeAliaser(){ super(AliasManager.Biome.name()); }
 	@Override

--- a/src/com/ModDamage/Alias/CommandAliaser.java
+++ b/src/com/ModDamage/Alias/CommandAliaser.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
 import com.ModDamage.Parsing.IDataProvider;
@@ -16,16 +17,16 @@ public class CommandAliaser extends CollectionAliaser<String>
 	public static CommandAliaser aliaser = new CommandAliaser();
 	private final Map<InfoOtherPair<String>, Collection<IDataProvider<String>>> aliasedCommands = new HashMap<InfoOtherPair<String>, Collection<IDataProvider<String>>>();
 	
-	public static Collection<IDataProvider<String>> match(String string, EventInfo info) {
+	public static Collection<IDataProvider<String>> match(ScriptLine scriptLine, String string, EventInfo info) {
 		InfoOtherPair<String> infoPair = new InfoOtherPair<String>(string, info);
 		if (aliaser.aliasedCommands.containsKey(infoPair)) return aliaser.aliasedCommands.get(infoPair);
 		
-		Collection<String> strings = aliaser.matchAlias(string);
+		Collection<String> strings = aliaser.matchAlias(scriptLine, string);
 		if (strings == null) return null;
 		Collection<IDataProvider<String>> istrings = new ArrayList<IDataProvider<String>>();
 		
 		for (String str : strings)
-			istrings.add(DataProvider.parse(info, String.class, str));
+			istrings.add(DataProvider.parse(scriptLine, info, String.class, str));
 		
 		aliaser.aliasedCommands.put(infoPair, istrings);
 		
@@ -35,7 +36,7 @@ public class CommandAliaser extends CollectionAliaser<String>
 	public CommandAliaser() { super(AliasManager.Command.name()); }
 	
 	@Override
-	public Collection<String> matchAlias(String cmd) {
+	public Collection<String> matchAlias(ScriptLine scriptLine, String cmd) {
 		if(hasAlias(cmd))
 			return getAlias(cmd);
 		return Arrays.asList(cmd);

--- a/src/com/ModDamage/Alias/EnchantmentAliaser.java
+++ b/src/com/ModDamage/Alias/EnchantmentAliaser.java
@@ -5,11 +5,13 @@ import java.util.Collection;
 import org.bukkit.enchantments.Enchantment;
 
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
+import com.ModDamage.Backend.ScriptLine;
 
 public class EnchantmentAliaser extends CollectionAliaser<Enchantment> 
 {
 	public static EnchantmentAliaser aliaser = new EnchantmentAliaser();
-	public static Collection<Enchantment> match(String string) { return aliaser.matchAlias(string); }
+	public static Collection<Enchantment> match(ScriptLine scriptLine) { return aliaser.matchAlias(scriptLine); }
+	public static Collection<Enchantment> match(ScriptLine scriptLine, String string) { return aliaser.matchAlias(scriptLine, string); }
 	
 	public EnchantmentAliaser(){ super(AliasManager.Enchantment.name()); }
 

--- a/src/com/ModDamage/Alias/GroupAliaser.java
+++ b/src/com/ModDamage/Alias/GroupAliaser.java
@@ -3,11 +3,13 @@ package com.ModDamage.Alias;
 import java.util.Collection;
 
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
+import com.ModDamage.Backend.ScriptLine;
 
 public class GroupAliaser extends CollectionAliaser<String> 
 {
 	public static GroupAliaser aliaser = new GroupAliaser();
-	public static Collection<String> match(String string) { return aliaser.matchAlias(string); }
+	public static Collection<String> match(ScriptLine scriptLine) { return aliaser.matchAlias(scriptLine); }
+	public static Collection<String> match(ScriptLine scriptLine, String string) { return aliaser.matchAlias(scriptLine, string); }
 	
 	public GroupAliaser() { super(AliasManager.Group.name()); }
 

--- a/src/com/ModDamage/Alias/ItemAliaser.java
+++ b/src/com/ModDamage/Alias/ItemAliaser.java
@@ -10,12 +10,13 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
 import com.ModDamage.Backend.ModDamageItemStack;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventInfo;
 
 public class ItemAliaser extends CollectionAliaser<String> 
 {
 	public static ItemAliaser aliaser = new ItemAliaser();
-	public static List<ModDamageItemStack> match(String string, EventInfo info) { return aliaser.matchAlias(string, info); }
+	public static List<ModDamageItemStack> match(ScriptLine line, String string, EventInfo info) { return aliaser.matchAlias(line, string, info); }
 	
 	public ItemAliaser() { super(AliasManager.Item.name()); }
 	
@@ -28,7 +29,7 @@ public class ItemAliaser extends CollectionAliaser<String>
 	static final Pattern commaPattern = Pattern.compile("\\s*,\\s*");
 	
 	
-	public List<ModDamageItemStack> matchAlias(String key, EventInfo info)
+	public List<ModDamageItemStack> matchAlias(ScriptLine line, String key, EventInfo info)
 	{
 		Collection<String> values = getAlias(key);
 		if (values == null)
@@ -36,7 +37,7 @@ public class ItemAliaser extends CollectionAliaser<String>
 			if (key.startsWith("_")) {
 				if (hasAlias(key))
 					return Arrays.<ModDamageItemStack>asList(); // hmm, not ready yet?
-				LogUtil.error("Unknown alias: \"" + key + "\"");
+				LogUtil.error(line, "Unknown alias: \"" + key + "\"");
 				return null;
 			}
 			values = new ArrayList<String>();
@@ -49,7 +50,7 @@ public class ItemAliaser extends CollectionAliaser<String>
 		{
 			StringMatcher sm = new StringMatcher(itemStr);
 			while(true) {
-				ModDamageItemStack item = ModDamageItemStack.getNewFromFront(info, sm.spawn());
+				ModDamageItemStack item = ModDamageItemStack.getNewFromFront(line, info, sm.spawn());
 				if (item == null) return null;
 				items.add(item);
 				
@@ -58,7 +59,7 @@ public class ItemAliaser extends CollectionAliaser<String>
 				if (sm.isEmpty())
 					break;
 				
-				LogUtil.error("Unidentified Yucky Stuff: \""+ sm.string +"\"");
+				LogUtil.error(line, "Unidentified Yucky Stuff: \""+ sm.string +"\"");
 				return null;
 			}
 		}

--- a/src/com/ModDamage/Alias/MaterialAliaser.java
+++ b/src/com/ModDamage/Alias/MaterialAliaser.java
@@ -5,11 +5,13 @@ import java.util.Collection;
 import org.bukkit.Material;
 
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
+import com.ModDamage.Backend.ScriptLine;
 
 public class MaterialAliaser extends CollectionAliaser<Material> 
 {
 	public static MaterialAliaser aliaser = new MaterialAliaser();
-	public static Collection<Material> match(String string) { return aliaser.matchAlias(string); }
+	public static Collection<Material> match(ScriptLine scriptLine) { return aliaser.matchAlias(scriptLine); }
+	public static Collection<Material> match(ScriptLine scriptLine, String string) { return aliaser.matchAlias(scriptLine, string); }
 	
 	public MaterialAliaser() { super(AliasManager.Material.name()); }
 

--- a/src/com/ModDamage/Alias/MessageAliaser.java
+++ b/src/com/ModDamage/Alias/MessageAliaser.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.InterpolatedString;
 import com.ModDamage.Parsing.IDataProvider;
@@ -16,16 +17,16 @@ public class MessageAliaser extends CollectionAliaser<String>
 	public static MessageAliaser aliaser = new MessageAliaser();
 	private final Map<InfoOtherPair<String>, Collection<IDataProvider<String>>> aliasedMessages = new HashMap<InfoOtherPair<String>, Collection<IDataProvider<String>>>();
 	
-	public static Collection<IDataProvider<String>> match(String string, EventInfo info) {
+	public static Collection<IDataProvider<String>> match(ScriptLine scriptLine, String string, EventInfo info) {
 		InfoOtherPair<String> infoPair = new InfoOtherPair<String>(string, info);
 		if (aliaser.aliasedMessages.containsKey(infoPair)) return aliaser.aliasedMessages.get(infoPair);
 		
-		Collection<String> strings = aliaser.matchAlias(string);
+		Collection<String> strings = aliaser.matchAlias(scriptLine, string);
 		if (strings == null) return null;
 		Collection<IDataProvider<String>> istrings = new ArrayList<IDataProvider<String>>();
 		
 		for (String str : strings)
-			istrings.add(new InterpolatedString(str, info, true));
+			istrings.add(new InterpolatedString(scriptLine, str, info, true));
 		
 		aliaser.aliasedMessages.put(infoPair, istrings);
 		
@@ -35,7 +36,7 @@ public class MessageAliaser extends CollectionAliaser<String>
 	public MessageAliaser() { super(AliasManager.Message.name()); }
 	
 	@Override
-	public Collection<String> matchAlias(String msg) {
+	public Collection<String> matchAlias(ScriptLine line, String msg) {
 		if(hasAlias(msg))
 			return getAlias(msg);
 		return Arrays.asList(msg);

--- a/src/com/ModDamage/Alias/RegionAliaser.java
+++ b/src/com/ModDamage/Alias/RegionAliaser.java
@@ -5,11 +5,13 @@ import java.util.Collection;
 import com.ModDamage.LogUtil;
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
 import com.ModDamage.Backend.ExternalPluginManager;
+import com.ModDamage.Backend.ScriptLine;
 
 public class RegionAliaser extends CollectionAliaser<String> 
 {
 	public static RegionAliaser aliaser = new RegionAliaser();
-	public static Collection<String> match(String string) { return aliaser.matchAlias(string); }
+	public static Collection<String> match(ScriptLine scriptLine) { return aliaser.matchAlias(scriptLine); }
+	public static Collection<String> match(ScriptLine scriptLine, String string) { return aliaser.matchAlias(scriptLine, string); }
 	
 	public RegionAliaser() { super(AliasManager.Region.name()); }
 

--- a/src/com/ModDamage/Alias/TypeAliaser.java
+++ b/src/com/ModDamage/Alias/TypeAliaser.java
@@ -3,12 +3,14 @@ package com.ModDamage.Alias;
 import java.util.Collection;
 
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.Matchables.EntityType;
 
 public class TypeAliaser extends CollectionAliaser<EntityType> 
 {
 	public static TypeAliaser aliaser = new TypeAliaser();
-	public static Collection<EntityType> match(String string) { return aliaser.matchAlias(string); }
+	public static Collection<EntityType> match(ScriptLine scriptLine) { return aliaser.matchAlias(scriptLine); }
+	public static Collection<EntityType> match(ScriptLine scriptLine, String string) { return aliaser.matchAlias(scriptLine, string); }
 	
 	public TypeAliaser() {super(AliasManager.Type.name()); }
 

--- a/src/com/ModDamage/Alias/WorldAliaser.java
+++ b/src/com/ModDamage/Alias/WorldAliaser.java
@@ -7,11 +7,13 @@ import org.bukkit.Bukkit;
 
 import com.ModDamage.LogUtil;
 import com.ModDamage.Alias.Aliaser.CollectionAliaser;
+import com.ModDamage.Backend.ScriptLine;
 
 public class WorldAliaser extends CollectionAliaser<String> 
 {
 	public static WorldAliaser aliaser = new WorldAliaser();
-	public static Collection<String> match(String string) { return aliaser.matchAlias(string); }
+	public static Collection<String> match(ScriptLine scriptLine) { return aliaser.matchAlias(scriptLine); }
+	public static Collection<String> match(ScriptLine scriptLine, String string) { return aliaser.matchAlias(scriptLine, string); }
 	
 	public WorldAliaser() {super(AliasManager.World.name()); }
 

--- a/src/com/ModDamage/Backend/ModDamageItemStack.java
+++ b/src/com/ModDamage/Backend/ModDamageItemStack.java
@@ -116,12 +116,12 @@ public class ModDamageItemStack
 	
 	public static final Pattern materialPattern = Pattern.compile("(\\w+)(?=[@*]|$)"); // word followed by @ * or nothing
 	
-	public static ModDamageItemStack getNewFromFront(EventInfo info, StringMatcher sm)
+	public static ModDamageItemStack getNewFromFront(ScriptLine line, EventInfo info, StringMatcher sm)
 	{
 		Matcher m = sm.matchFront(materialPattern);
 		if (m == null) return null;
 		
-		Collection<Material> materials = MaterialAliaser.match(m.group());
+		Collection<Material> materials = MaterialAliaser.match(line, m.group());
 		Material first = null;
 		
 		if (materials != null && materials.size() > 0)
@@ -129,13 +129,13 @@ public class ModDamageItemStack
 			
 		if (first == null)
 		{
-			LogUtil.error("Error: unable to match material \"" + m.group() + "\"");
+			LogUtil.error(line, "Error: unable to match material \"" + m.group() + "\"");
 			return null;
 		}
 		
 		if (materials == null || materials.size() > 1)
 		{
-			LogUtil.error("Error: matched "+(materials == null? 0:materials.size())+" materials, wanted only one: \"" + m.group() + "\"");
+			LogUtil.error(line, "Error: matched "+(materials == null? 0:materials.size())+" materials, wanted only one: \"" + m.group() + "\"");
 			return null;
 		}
 		
@@ -144,7 +144,7 @@ public class ModDamageItemStack
 		IDataProvider<Integer> data;
 		if (sm.matchesFront("@"))
 		{
-			data = DataProvider.parse(info, Integer.class, sm.spawn());
+			data = DataProvider.parse(line, info, Integer.class, sm.spawn());
 			if (data == null) return null;
 		}
 		else
@@ -154,7 +154,7 @@ public class ModDamageItemStack
 		IDataProvider<? extends Number> amount;
 		if (sm.matchesFront("*"))
 		{
-			amount = DataProvider.parse(info, Integer.class, sm.spawn());
+			amount = DataProvider.parse(line, info, Integer.class, sm.spawn());
 			if (amount == null) return null;
 		}
 		else

--- a/src/com/ModDamage/Conditionals/Chance.java
+++ b/src/com/ModDamage/Conditionals/Chance.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -41,9 +42,9 @@ public class Chance implements IDataProvider<Boolean>
 		DataProvider.register(Boolean.class, pattern, new BaseDataParser<Boolean>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine line, EventInfo info, Matcher m, StringMatcher sm)
 				{
-					IDataProvider<Integer> probability = DataProvider.parse(info, Integer.class, sm.spawn());
+					IDataProvider<Integer> probability = DataProvider.parse(line, info, Integer.class, sm.spawn());
 					if (probability == null) return null;
 					
 					sm.accept();

--- a/src/com/ModDamage/Conditionals/Comparison.java
+++ b/src/com/ModDamage/Conditionals/Comparison.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -119,11 +120,11 @@ public class Comparison extends Conditional<Number>
 		DataProvider.register(Boolean.class, Number.class, operatorPattern, new IDataParser<Boolean, Number>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Number> leftDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine line, EventInfo info, IDataProvider<Number> leftDP, Matcher m, StringMatcher sm)
 				{
 					ComparisonType comparisonType = ComparisonType.nameMap.get(m.group(1));
 					
-					IDataProvider<Number> right = DataProvider.parse(info, Number.class, sm.spawn());
+					IDataProvider<Number> right = DataProvider.parse(line, info, Number.class, sm.spawn());
 					
 					if(comparisonType == null)
 						return null;

--- a/src/com/ModDamage/Conditionals/CompoundConditional.java
+++ b/src/com/ModDamage/Conditionals/CompoundConditional.java
@@ -10,6 +10,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 
@@ -123,11 +124,11 @@ public class CompoundConditional extends Conditional<Boolean>
 		DataProvider.register(Boolean.class, Boolean.class, LogicalOperator.pattern, new IDataParser<Boolean, Boolean>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Boolean> leftDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine line, EventInfo info, IDataProvider<Boolean> leftDP, Matcher m, StringMatcher sm)
 				{
 					LogicalOperator operator = LogicalOperator.match(m.group(1));
 					
-					IDataProvider<Boolean> rightDP = DataProvider.parse(info, Boolean.class, sm.spawn());
+					IDataProvider<Boolean> rightDP = DataProvider.parse(line, info, Boolean.class, sm.spawn());
 					if (rightDP == null) return null;
 					
 					sm.accept();

--- a/src/com/ModDamage/Conditionals/EntityBlockStatus.java
+++ b/src/com/ModDamage/Conditionals/EntityBlockStatus.java
@@ -12,6 +12,7 @@ import com.ModDamage.ModDamage;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Alias.MaterialAliaser;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -137,7 +138,7 @@ public class EntityBlockStatus extends Conditional<Entity>
 		DataProvider.register(Boolean.class, Entity.class, pattern, new IDataParser<Boolean, Entity>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Entity> entityDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine line, EventInfo info, IDataProvider<Entity> entityDP, Matcher m, StringMatcher sm)
 				{
 					BlockStatusType statusType = null;
 					for(BlockStatusType type : BlockStatusType.values())
@@ -145,7 +146,7 @@ public class EntityBlockStatus extends Conditional<Entity>
 								statusType = type;
 					if(statusType == null) return null;
 					
-					Collection<Material> materials = MaterialAliaser.match(m.group(2));
+					Collection<Material> materials = MaterialAliaser.match(line, m.group(2));
 					if (materials == null || materials.isEmpty()) return null;
 					
 					return new EntityBlockStatus(entityDP, statusType, materials);

--- a/src/com/ModDamage/Conditionals/EntityHasPotionEffect.java
+++ b/src/com/ModDamage/Conditionals/EntityHasPotionEffect.java
@@ -12,6 +12,7 @@ import com.ModDamage.Parsing.DataProvider;
 import com.ModDamage.Parsing.IDataParser;
 import com.ModDamage.Parsing.IDataProvider;
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 
@@ -49,7 +50,7 @@ public class EntityHasPotionEffect extends Conditional<LivingEntity>
 		DataProvider.register(Boolean.class, LivingEntity.class, pattern, new IDataParser<Boolean, LivingEntity>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<LivingEntity> livingDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine line, EventInfo info, IDataProvider<LivingEntity> livingDP, Matcher m, StringMatcher sm)
 				{
 					String[] effectTypeStrs = m.group(1).split(",");
 					PotionEffectType[] effectTypes = new PotionEffectType[effectTypeStrs.length];
@@ -59,7 +60,7 @@ public class EntityHasPotionEffect extends Conditional<LivingEntity>
 						effectTypes[i] = PotionEffectType.getByName(effectTypeStrs[i].toUpperCase());
 						if (effectTypes[i] == null)
 						{
-							LogUtil.error("Unknown potion effect type '"+effectTypeStrs[i]+"'");
+							LogUtil.error(line, "Unknown potion effect type '"+effectTypeStrs[i]+"'");
 							return null;
 						}
 					}

--- a/src/com/ModDamage/Conditionals/EntityStatus.java
+++ b/src/com/ModDamage/Conditionals/EntityStatus.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.LivingEntity;
 import com.ModDamage.ModDamage;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -97,7 +98,7 @@ public class EntityStatus extends Conditional<Entity>
 		DataProvider.register(Boolean.class, Entity.class, pattern, new IDataParser<Boolean, Entity>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Entity> entityDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Entity> entityDP, Matcher m, StringMatcher sm)
 				{
 					StatusType statusType = null;
 					for(StatusType type : StatusType.values())

--- a/src/com/ModDamage/Conditionals/EnumEquals.java
+++ b/src/com/ModDamage/Conditionals/EnumEquals.java
@@ -13,6 +13,7 @@ import com.ModDamage.Parsing.IDataParser;
 import com.ModDamage.Parsing.IDataProvider;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Matchables.Matchable;
@@ -62,7 +63,7 @@ public class EnumEquals extends Conditional<Enum>
 		DataProvider.register(Boolean.class, Enum.class, pattern, new IDataParser<Boolean, Enum>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Enum> enumDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Enum> enumDP, Matcher m, StringMatcher sm)
 				{
 					@SuppressWarnings("unchecked")
 					Map<String, Enum<?>> possibleTypes = Utils.getTypeMapForEnum(enumDP.provides(), true);
@@ -79,7 +80,7 @@ public class EnumEquals extends Conditional<Enum>
 								types.add(null);
 								continue;
 							}
-							LogUtil.error("Error: \"" + typeStr + "\" is not a valid " + enumDP.provides().getSimpleName());
+							LogUtil.error(scriptLine, "Error: \"" + typeStr + "\" is not a valid " + enumDP.provides().getSimpleName());
 							return null;
 						}
 						types.add(type);

--- a/src/com/ModDamage/Conditionals/Equality.java
+++ b/src/com/ModDamage/Conditionals/Equality.java
@@ -7,6 +7,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -65,13 +66,13 @@ public class Equality extends Conditional<Object>
 			{
 				@SuppressWarnings({ "unchecked", "rawtypes" })
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Object> leftDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Object> leftDP, Matcher m, StringMatcher sm)
 				{
 					if (leftDP == null) return null;
 					
 					boolean equalTo = !m.group(1).equals("!");
 					
-					IDataProvider<Object> right = DataProvider.parse(info, null, sm.spawn());
+					IDataProvider<Object> right = DataProvider.parse(scriptLine, info, null, sm.spawn());
 					if (right == null) return null;
 					
 					if (Number.class.isAssignableFrom(leftDP.provides()) || Number.class.isAssignableFrom(right.provides())) {
@@ -87,7 +88,7 @@ public class Equality extends Conditional<Object>
 							if (transformed != null)
 								leftDP = (IDataProvider<Object>) transformed;
 							else {
-								LogUtil.error("Cannot compare equality of types " + leftDP.provides().getSimpleName() + " and " + right.provides().getSimpleName());
+								LogUtil.error(scriptLine, "Cannot compare equality of types " + leftDP.provides().getSimpleName() + " and " + right.provides().getSimpleName());
 								return null;
 							}
 						}

--- a/src/com/ModDamage/Conditionals/InvertBoolean.java
+++ b/src/com/ModDamage/Conditionals/InvertBoolean.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -38,9 +39,9 @@ public class InvertBoolean implements IDataProvider<Boolean>
 		DataProvider.register(Boolean.class, pattern, new BaseDataParser<Boolean>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 				{
-					IDataProvider<Boolean> bool = DataProvider.parse(info, Boolean.class, sm.spawn());
+					IDataProvider<Boolean> bool = DataProvider.parse(scriptLine, info, Boolean.class, sm.spawn());
 					if (bool == null) return null;
 					
 					sm.accept();

--- a/src/com/ModDamage/Conditionals/IsTagged.java
+++ b/src/com/ModDamage/Conditionals/IsTagged.java
@@ -4,13 +4,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.Expressions.InterpolatedString;
 import com.ModDamage.Parsing.DataProvider;
 import com.ModDamage.Parsing.IDataParser;
 import com.ModDamage.Parsing.IDataProvider;
 import com.ModDamage.Tags.Tag;
 import com.ModDamage.Tags.Taggable;
-
 import com.ModDamage.StringMatcher;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
@@ -44,9 +44,9 @@ public class IsTagged<T> extends Conditional<T>
 			{
 				@Override
                 @SuppressWarnings({ "unchecked", "rawtypes" })
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Object> objDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Object> objDP, Matcher m, StringMatcher sm)
 				{
-                    Tag<?> tag = Tag.get(InterpolatedString.parseWord(InterpolatedString.word, sm.spawn(), info), m.group(1));
+                    Tag<?> tag = Tag.get(InterpolatedString.parseWord(scriptLine, InterpolatedString.word, sm.spawn(), info), m.group(1));
                     Taggable<?> taggable = Taggable.get(objDP, info);
                     if (tag == null || taggable == null) return null;
 

--- a/src/com/ModDamage/Conditionals/ItemMatches.java
+++ b/src/com/ModDamage/Conditionals/ItemMatches.java
@@ -11,6 +11,7 @@ import com.ModDamage.Alias.ItemAliaser;
 import com.ModDamage.Backend.BailException;
 import com.ModDamage.Backend.ItemHolder;
 import com.ModDamage.Backend.ModDamageItemStack;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -52,13 +53,13 @@ public class ItemMatches extends Conditional<ItemHolder>
 		DataProvider.register(Boolean.class, ItemHolder.class, pattern, new IDataParser<Boolean, ItemHolder>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<ItemHolder> itemDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<ItemHolder> itemDP, Matcher m, StringMatcher sm)
 				{
-					Collection<ModDamageItemStack> matchedItems = ItemAliaser.match(m.group(2), info);
+					Collection<ModDamageItemStack> matchedItems = ItemAliaser.match(scriptLine, m.group(2), info);
 					if(matchedItems == null || matchedItems.isEmpty()) return null;
 						
 					if (m.group(1).equalsIgnoreCase("material"))
-						LogUtil.warning_strong("Using the material version is deprecated. Please use '"+ itemDP +".matches."+ m.group(2) +"' instead.");
+						LogUtil.warning_strong(scriptLine, "Using the material version is deprecated. Please use '"+ itemDP +".matches."+ m.group(2) +"' instead.");
 					
 					return new ItemMatches(itemDP, matchedItems);
 				}

--- a/src/com/ModDamage/Conditionals/LivingEntityStatus.java
+++ b/src/com/ModDamage/Conditionals/LivingEntityStatus.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.LivingEntity;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -54,7 +55,7 @@ public class LivingEntityStatus extends Conditional<LivingEntity>
 		DataProvider.register(Boolean.class, LivingEntity.class, pattern, new IDataParser<Boolean, LivingEntity>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<LivingEntity> livingDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<LivingEntity> livingDP, Matcher m, StringMatcher sm)
 				{
 					StatusType statusType = null;
 					for(StatusType type : StatusType.values())

--- a/src/com/ModDamage/Conditionals/LocationBiome.java
+++ b/src/com/ModDamage/Conditionals/LocationBiome.java
@@ -10,6 +10,7 @@ import org.bukkit.block.Biome;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Alias.BiomeAliaser;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -45,9 +46,9 @@ public class LocationBiome extends Conditional<Location>
 		DataProvider.register(Boolean.class, Location.class, pattern, new IDataParser<Boolean, Location>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Location> locDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Location> locDP, Matcher m, StringMatcher sm)
 				{
-					Collection<Biome> biomes = BiomeAliaser.match(m.group(1));
+					Collection<Biome> biomes = BiomeAliaser.match(scriptLine, m.group(1));
 					if(biomes.isEmpty()) return null;
 					
 					return new LocationBiome(locDP, biomes);

--- a/src/com/ModDamage/Conditionals/LocationRegion.java
+++ b/src/com/ModDamage/Conditionals/LocationRegion.java
@@ -10,6 +10,7 @@ import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Alias.RegionAliaser;
 import com.ModDamage.Backend.ExternalPluginManager;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -65,9 +66,9 @@ public class LocationRegion extends Conditional<Location>
 		DataProvider.register(Boolean.class, Location.class, pattern, new IDataParser<Boolean, Location>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Location> locDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Location> locDP, Matcher m, StringMatcher sm)
 				{
-					Collection<String> regions = RegionAliaser.match(m.group(2));
+					Collection<String> regions = RegionAliaser.match(scriptLine, m.group(2));
 					if(regions.isEmpty()) return null;
 					
 					return new LocationRegion(locDP, m.group(1) != null, regions);

--- a/src/com/ModDamage/Conditionals/PlayerCanSee.java
+++ b/src/com/ModDamage/Conditionals/PlayerCanSee.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -46,9 +47,9 @@ public class PlayerCanSee extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
-                    IDataProvider<Player> otherDP = DataProvider.parse(info, Player.class, sm.spawn());
+                    IDataProvider<Player> otherDP = DataProvider.parse(scriptLine, info, Player.class, sm.spawn());
                     if (otherDP == null) return null;
 
                     return sm.acceptIf(new PlayerCanSee(playerDP, otherDP));

--- a/src/com/ModDamage/Conditionals/PlayerGameMode.java
+++ b/src/com/ModDamage/Conditionals/PlayerGameMode.java
@@ -1,11 +1,13 @@
 package com.ModDamage.Conditionals;
 
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
 import com.ModDamage.Parsing.IDataParser;
 import com.ModDamage.Parsing.IDataProvider;
 import com.ModDamage.StringMatcher;
+
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 
@@ -42,7 +44,7 @@ public class PlayerGameMode extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
                     try
                     {

--- a/src/com/ModDamage/Conditionals/PlayerHasEnchantment.java
+++ b/src/com/ModDamage/Conditionals/PlayerHasEnchantment.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Alias.EnchantmentAliaser;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -49,9 +50,9 @@ public class PlayerHasEnchantment extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
-					Collection<Enchantment> enchantments = EnchantmentAliaser.match(m.group(1));
+					Collection<Enchantment> enchantments = EnchantmentAliaser.match(scriptLine, m.group(1));
 					if(enchantments.isEmpty())	return null;
 					
 					return new PlayerHasEnchantment(playerDP, enchantments);

--- a/src/com/ModDamage/Conditionals/PlayerHasItem.java
+++ b/src/com/ModDamage/Conditionals/PlayerHasItem.java
@@ -13,6 +13,7 @@ import com.ModDamage.Utils;
 import com.ModDamage.Alias.ItemAliaser;
 import com.ModDamage.Backend.BailException;
 import com.ModDamage.Backend.ModDamageItemStack;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -88,9 +89,9 @@ public class PlayerHasItem extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
-					List<ModDamageItemStack> items = ItemAliaser.match(m.group(2), info);
+					List<ModDamageItemStack> items = ItemAliaser.match(scriptLine, m.group(2), info);
 					if(items == null || items.isEmpty()) return null;
 					
 					return new PlayerHasItem(playerDP, m.group(1) != null, items);

--- a/src/com/ModDamage/Conditionals/PlayerHasPermission.java
+++ b/src/com/ModDamage/Conditionals/PlayerHasPermission.java
@@ -4,7 +4,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.Expressions.InterpolatedString;
+
 import org.bukkit.entity.Player;
 
 import com.ModDamage.StringMatcher;
@@ -45,9 +47,9 @@ public class PlayerHasPermission extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
-                    IDataProvider<String> permissionDP = InterpolatedString.parseWord(wordPattern, sm.spawn(), info);
+                    IDataProvider<String> permissionDP = InterpolatedString.parseWord(scriptLine, wordPattern, sm.spawn(), info);
                     if (permissionDP == null) return null;
 
                     sm.accept();

--- a/src/com/ModDamage/Conditionals/PlayerInGroup.java
+++ b/src/com/ModDamage/Conditionals/PlayerInGroup.java
@@ -10,6 +10,7 @@ import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Alias.GroupAliaser;
 import com.ModDamage.Backend.ExternalPluginManager;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -48,9 +49,9 @@ public class PlayerInGroup extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
-					Collection<String> matchedGroups = GroupAliaser.match(m.group(1));
+					Collection<String> matchedGroups = GroupAliaser.match(scriptLine, m.group(1));
 					if(!matchedGroups.isEmpty())
 						return new PlayerInGroup(playerDP, matchedGroups);
 					return null;

--- a/src/com/ModDamage/Conditionals/PlayerNamed.java
+++ b/src/com/ModDamage/Conditionals/PlayerNamed.java
@@ -1,6 +1,7 @@
 package com.ModDamage.Conditionals;
 
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.InterpolatedString;
@@ -9,6 +10,7 @@ import com.ModDamage.Parsing.IDataParser;
 import com.ModDamage.Parsing.IDataProvider;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
+
 import org.bukkit.entity.Player;
 
 import java.util.Collection;
@@ -25,9 +27,9 @@ public class PlayerNamed extends Conditional<Player>
         DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
         {
             @Override
-            public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+            public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
             {
-                Collection<IDataProvider<String>> names = InterpolatedString.parseWordList(wordPattern, InterpolatedString.comma, sm, info);
+                Collection<IDataProvider<String>> names = InterpolatedString.parseWordList(scriptLine, wordPattern, InterpolatedString.comma, sm, info);
 
                 return new PlayerNamed(playerDP, names);
             }

--- a/src/com/ModDamage/Conditionals/PlayerStatus.java
+++ b/src/com/ModDamage/Conditionals/PlayerStatus.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -74,7 +75,7 @@ public class PlayerStatus extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> entityDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> entityDP, Matcher m, StringMatcher sm)
 				{
                 StatusType statusType = null;
                 for(StatusType type : StatusType.values())

--- a/src/com/ModDamage/Conditionals/PlayerWearing.java
+++ b/src/com/ModDamage/Conditionals/PlayerWearing.java
@@ -10,6 +10,7 @@ import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Alias.ArmorAliaser;
 import com.ModDamage.Backend.ArmorSet;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -52,9 +53,9 @@ public class PlayerWearing extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
-					Collection<ArmorSet> armorSet = ArmorAliaser.match(m.group(2));
+					Collection<ArmorSet> armorSet = ArmorAliaser.match(scriptLine, m.group(2));
 					if(armorSet.isEmpty()) return null;
 					
 					return new PlayerWearing(playerDP, m.group(1) != null, armorSet);

--- a/src/com/ModDamage/Conditionals/PlayerWielding.java
+++ b/src/com/ModDamage/Conditionals/PlayerWielding.java
@@ -12,6 +12,7 @@ import com.ModDamage.Utils;
 import com.ModDamage.Alias.ItemAliaser;
 import com.ModDamage.Backend.BailException;
 import com.ModDamage.Backend.ModDamageItemStack;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -54,9 +55,9 @@ public class PlayerWielding extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
-					Collection<ModDamageItemStack> matchedItems = ItemAliaser.match(m.group(1), info);
+					Collection<ModDamageItemStack> matchedItems = ItemAliaser.match(scriptLine, m.group(1), info);
 					if(matchedItems == null || matchedItems.isEmpty()) return null;
 					
 					return new PlayerWielding(playerDP, matchedItems);

--- a/src/com/ModDamage/Conditionals/ServerOnlineMode.java
+++ b/src/com/ModDamage/Conditionals/ServerOnlineMode.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import org.bukkit.Bukkit;
 
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -30,7 +31,7 @@ public class ServerOnlineMode implements IDataProvider<Boolean>
 		DataProvider.register(Boolean.class, pattern, new BaseDataParser<Boolean>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 				{
 					return new ServerOnlineMode();
 				}

--- a/src/com/ModDamage/Conditionals/StringConditionals.java
+++ b/src/com/ModDamage/Conditionals/StringConditionals.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -91,7 +92,7 @@ public class StringConditionals extends Conditional<String>
 		DataProvider.register(Boolean.class, String.class, pattern, new IDataParser<Boolean, String>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<String> entityDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<String> entityDP, Matcher m, StringMatcher sm)
 				{
 					StringConditional statusType = null;
 					for(StringConditional type : StringConditional.values())
@@ -101,7 +102,7 @@ public class StringConditionals extends Conditional<String>
 					
 					boolean caseInsensitive = (m.group(1) != null);
 					
-					IDataProvider<String> otherString = DataProvider.parse(info, String.class, sm);
+					IDataProvider<String> otherString = DataProvider.parse(scriptLine, info, String.class, sm);
 					
 					return new StringConditionals(entityDP, caseInsensitive, statusType, otherString);
 				}

--- a/src/com/ModDamage/Conditionals/StringMatches.java
+++ b/src/com/ModDamage/Conditionals/StringMatches.java
@@ -7,6 +7,7 @@ import java.util.regex.PatternSyntaxException;
 import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -42,7 +43,7 @@ public class StringMatches extends Conditional<String>
 		DataProvider.register(Boolean.class, String.class, pattern, new IDataParser<Boolean, String>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<String> stringDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<String> stringDP, Matcher m, StringMatcher sm)
 				{
 					String p = m.group(2);
 					if (p == null)
@@ -57,7 +58,7 @@ public class StringMatches extends Conditional<String>
 					}
 					catch (PatternSyntaxException ps)
 					{
-						LogUtil.error("Invalid regex: " + ps.getDescription());
+						LogUtil.error(scriptLine, "Invalid regex: " + ps.getDescription());
 						return null;
 					}
 					

--- a/src/com/ModDamage/Conditionals/WorldEnvironment.java
+++ b/src/com/ModDamage/Conditionals/WorldEnvironment.java
@@ -7,6 +7,7 @@ import org.bukkit.World;
 import org.bukkit.World.Environment;
 
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -42,7 +43,7 @@ public class WorldEnvironment extends Conditional<World>
 		DataProvider.register(Boolean.class, World.class, pattern, new IDataParser<Boolean, World>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<World> worldDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<World> worldDP, Matcher m, StringMatcher sm)
 				{
 					try
 					{

--- a/src/com/ModDamage/Conditionals/WorldNamed.java
+++ b/src/com/ModDamage/Conditionals/WorldNamed.java
@@ -5,7 +5,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.Expressions.InterpolatedString;
+
 import org.bukkit.World;
 
 import com.ModDamage.StringMatcher;
@@ -51,9 +53,9 @@ public class WorldNamed extends Conditional<World>
 		DataProvider.register(Boolean.class, World.class, pattern, new IDataParser<Boolean, World>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<World> worldDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<World> worldDP, Matcher m, StringMatcher sm)
 				{
-                    Collection<IDataProvider<String>> names = InterpolatedString.parseWordList(wordPattern, InterpolatedString.comma, sm, info);
+                    Collection<IDataProvider<String>> names = InterpolatedString.parseWordList(scriptLine, wordPattern, InterpolatedString.comma, sm, info);
 
                     return new WorldNamed(worldDP, names);
 				}

--- a/src/com/ModDamage/Conditionals/WorldStatus.java
+++ b/src/com/ModDamage/Conditionals/WorldStatus.java
@@ -7,6 +7,7 @@ import org.bukkit.World;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -50,7 +51,7 @@ public class WorldStatus extends Conditional<World>
 		DataProvider.register(Boolean.class, World.class, pattern, new IDataParser<Boolean, World>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<World> worldDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<World> worldDP, Matcher m, StringMatcher sm)
 				{
 					WorldStatusType statusType = WorldStatusType.valueOf(m.group(1).toUpperCase());
 						

--- a/src/com/ModDamage/Expressions/Function/DistanceFunction.java
+++ b/src/com/ModDamage/Expressions/Function/DistanceFunction.java
@@ -11,6 +11,7 @@ import com.ModDamage.Parsing.IDataProvider;
 import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 
@@ -47,17 +48,17 @@ public class DistanceFunction implements IDataProvider<Integer>
 		DataProvider.register(Integer.class, Pattern.compile("(dist(?:ance)?)\\s*\\("), new BaseDataParser<Integer>()
 			{
 				@Override
-				public IDataProvider<Integer> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<Integer> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 				{
 					@SuppressWarnings("unchecked")
 					IDataProvider<Location>[] args = new IDataProvider[2];
 					
 					for (int i = 0; i < 2; i++)
 					{
-						IDataProvider<Location> arg = DataProvider.parse(info, Location.class, sm.spawn());
+						IDataProvider<Location> arg = DataProvider.parse(scriptLine, info, Location.class, sm.spawn());
 						if (arg == null)
 						{
-							LogUtil.error("Unable to match expression: \"" + sm.string + "\"");
+							LogUtil.error(scriptLine, "Unable to match expression: \"" + sm.string + "\"");
 							return null;
 						}
 						
@@ -65,7 +66,7 @@ public class DistanceFunction implements IDataProvider<Integer>
 						
 						if ((sm.matchFront(commaPattern) == null) != (i == 1))
 						{
-							LogUtil.error("Wrong number of parameters for " + m.group(1) + " function: "+i);
+							LogUtil.error(scriptLine, "Wrong number of parameters for " + m.group(1) + " function: "+i);
 							return null;
 						}
 					}
@@ -74,7 +75,7 @@ public class DistanceFunction implements IDataProvider<Integer>
 					Matcher endMatcher = sm.matchFront(endPattern);
 					if (endMatcher == null)
 					{
-						LogUtil.error("Missing end paren: \"" + sm.string + "\"");
+						LogUtil.error(scriptLine, "Missing end paren: \"" + sm.string + "\"");
 						return null;
 					}
 					

--- a/src/com/ModDamage/Expressions/Function/FormatFunction.java
+++ b/src/com/ModDamage/Expressions/Function/FormatFunction.java
@@ -9,6 +9,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -51,9 +52,9 @@ public class FormatFunction implements IDataProvider<String>
 		DataProvider.register(String.class, Pattern.compile("format\\("), new BaseDataParser<String>()
 			{
 				@Override
-				public IDataProvider<String> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<String> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 				{
-					IDataProvider<String> formatDP = DataProvider.parse(info, String.class, sm.spawn(), false, true, endPattern);
+					IDataProvider<String> formatDP = DataProvider.parse(scriptLine, info, String.class, sm.spawn(), false, true, endPattern);
 					if (formatDP == null) return null;
 					
 					List<IDataProvider<Object>> argsDP = new ArrayList<IDataProvider<Object>>();
@@ -62,7 +63,7 @@ public class FormatFunction implements IDataProvider<String>
 					{
 						Matcher em = sm.matchFront(endPattern);
 						if (em == null) {
-							LogUtil.error("Expected , or ) at \"" + sm.string + "\"");
+							LogUtil.error(scriptLine, "Expected , or ) at \"" + sm.string + "\"");
 							return null;
 						}
 						
@@ -70,7 +71,7 @@ public class FormatFunction implements IDataProvider<String>
 							break;
 						
 						
-						IDataProvider<Object> arg = DataProvider.parse(info, null, sm.spawn(), false, true, endPattern);
+						IDataProvider<Object> arg = DataProvider.parse(scriptLine, info, null, sm.spawn(), false, true, endPattern);
 						if (arg == null) return null;
 
 						argsDP.add(arg);

--- a/src/com/ModDamage/Expressions/Function/IndexOfFunction.java
+++ b/src/com/ModDamage/Expressions/Function/IndexOfFunction.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -47,17 +48,17 @@ public class IndexOfFunction extends DataProvider<Integer, String>
 		DataProvider.register(Integer.class, String.class, Pattern.compile("_(i)?indexOf\\("), new IDataParser<Integer, String>()
 			{
 				@Override
-				public IDataProvider<Integer> parse(EventInfo info, IDataProvider<String> stringDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Integer> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<String> stringDP, Matcher m, StringMatcher sm)
 				{
 					boolean caseInsensitive = (m.group(1) != null);
 					
-					IDataProvider<String> otherDP = DataProvider.parse(info, String.class, sm.spawn());
+					IDataProvider<String> otherDP = DataProvider.parse(scriptLine, info, String.class, sm.spawn());
 					if (otherDP == null) return null;
 
 					Matcher endMatcher = sm.matchFront(endPattern);
 					if (endMatcher == null)
 					{
-						LogUtil.error("Missing end paren: \"" + sm.string + "\"");
+						LogUtil.error(scriptLine, "Missing end paren: \"" + sm.string + "\"");
 						return null;
 					}
 

--- a/src/com/ModDamage/Expressions/Function/IntFunction.java
+++ b/src/com/ModDamage/Expressions/Function/IntFunction.java
@@ -13,6 +13,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 
@@ -132,22 +133,22 @@ public class IntFunction implements IDataProvider<Integer>
 		DataProvider.register(Integer.class, Pattern.compile("("+Utils.joinBy("|", FunctionType.values())+")\\s*\\(", Pattern.CASE_INSENSITIVE), new BaseDataParser<Integer>()
 			{
 				@Override
-				public IDataProvider<Integer> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<Integer> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 				{
 					FunctionType ftype = FunctionType.match(m.group(1));
 					if (ftype == null)
 					{
-						LogUtil.error("Unknown function named: \"" + m.group(1) + "\"");
+						LogUtil.error(scriptLine, "Unknown function named: \"" + m.group(1) + "\"");
 						return null;
 					}
 					
 					List<IDataProvider<Integer>> args = new ArrayList<IDataProvider<Integer>>();
 					while (true)
 					{
-						IDataProvider<Integer> arg = DataProvider.parse(info, Integer.class, sm.spawn());
+						IDataProvider<Integer> arg = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn());
 						if (arg == null)
 						{
-							LogUtil.error("Unable to match expression: \"" + sm.string + "\"");
+							LogUtil.error(scriptLine, "Unable to match expression: \"" + sm.string + "\"");
 							return null;
 						}
 						
@@ -161,13 +162,13 @@ public class IntFunction implements IDataProvider<Integer>
 					Matcher endMatcher = sm.matchFront(endPattern);
 					if (endMatcher == null)
 					{
-						LogUtil.error("Missing end paren: \"" + sm.string + "\"");
+						LogUtil.error(scriptLine, "Missing end paren: \"" + sm.string + "\"");
 						return null;
 					}
 					
 					if (args.size() < ftype.minParams || args.size() > ftype.maxParams)
 					{
-						LogUtil.error("Wrong number of parameters for " + m.group(1) + " function");
+						LogUtil.error(scriptLine, "Wrong number of parameters for " + m.group(1) + " function");
 						return null;
 					}
 					

--- a/src/com/ModDamage/Expressions/Function/LoreFunction.java
+++ b/src/com/ModDamage/Expressions/Function/LoreFunction.java
@@ -7,6 +7,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
 import com.ModDamage.Backend.ItemHolder;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -57,15 +58,15 @@ public class LoreFunction extends SettableDataProvider<String, ItemHolder>
 		DataProvider.register(String.class, ItemHolder.class, Pattern.compile("_lore\\("), new IDataParser<String, ItemHolder>()
 			{
 				@Override
-				public IDataProvider<String> parse(EventInfo info, IDataProvider<ItemHolder> holderDP, Matcher m, StringMatcher sm)
+				public IDataProvider<String> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<ItemHolder> holderDP, Matcher m, StringMatcher sm)
 				{
-					IDataProvider<Integer> indexDP = DataProvider.parse(info, Integer.class, sm.spawn());
+					IDataProvider<Integer> indexDP = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn());
 					if (indexDP == null) return null;
 
 					Matcher endMatcher = sm.matchFront(endPattern);
 					if (endMatcher == null)
 					{
-						LogUtil.error("Missing end paren: \"" + sm.string + "\"");
+						LogUtil.error(scriptLine, "Missing end paren: \"" + sm.string + "\"");
 						return null;
 					}
 

--- a/src/com/ModDamage/Expressions/Function/RegexReplaceFunction.java
+++ b/src/com/ModDamage/Expressions/Function/RegexReplaceFunction.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -54,17 +55,17 @@ public class RegexReplaceFunction extends DataProvider<String, String>
 		DataProvider.register(String.class, String.class, Pattern.compile("_(i)?r(?:e(?:gex)?)?replace(one|first)?\\("), new IDataParser<String, String>()
 			{
 				@Override
-				public IDataProvider<String> parse(EventInfo info, IDataProvider<String> worldDP, Matcher m, StringMatcher sm)
+				public IDataProvider<String> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<String> worldDP, Matcher m, StringMatcher sm)
 				{
 					@SuppressWarnings("unchecked")
 					IDataProvider<String>[] args = new IDataProvider[2];
 
 					for (int i = 0; i < 2; i++)
 					{
-						IDataProvider<String> arg = DataProvider.parse(info, String.class, sm.spawn());
+						IDataProvider<String> arg = DataProvider.parse(scriptLine, info, String.class, sm.spawn());
 						if (arg == null)
 						{
-							LogUtil.error("Unable to match expression: \"" + sm.string + "\"");
+							LogUtil.error(scriptLine, "Unable to match expression: \"" + sm.string + "\"");
 							return null;
 						}
 
@@ -72,7 +73,7 @@ public class RegexReplaceFunction extends DataProvider<String, String>
 
 						if (sm.matchesFront(commaPattern) != (i != 1))
 						{
-							LogUtil.error("Wrong number of parameters for replace" + (m.group(1) != null?m.group(1):"") + " function: "+i);
+							LogUtil.error(scriptLine, "Wrong number of parameters for replace" + (m.group(1) != null?m.group(1):"") + " function: "+i);
 							return null;
 						}
 					}
@@ -81,7 +82,7 @@ public class RegexReplaceFunction extends DataProvider<String, String>
 					Matcher endMatcher = sm.matchFront(endPattern);
 					if (endMatcher == null)
 					{
-						LogUtil.error("Missing end paren: \"" + sm.string + "\"");
+						LogUtil.error(scriptLine, "Missing end paren: \"" + sm.string + "\"");
 						return null;
 					}
 

--- a/src/com/ModDamage/Expressions/Function/ReplaceFunction.java
+++ b/src/com/ModDamage/Expressions/Function/ReplaceFunction.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -54,17 +55,17 @@ public class ReplaceFunction extends DataProvider<String, String>
 		DataProvider.register(String.class, String.class, Pattern.compile("_replace(one|first)?\\("), new IDataParser<String, String>()
 			{
 				@Override
-				public IDataProvider<String> parse(EventInfo info, IDataProvider<String> worldDP, Matcher m, StringMatcher sm)
+				public IDataProvider<String> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<String> worldDP, Matcher m, StringMatcher sm)
 				{
 					@SuppressWarnings("unchecked")
 					IDataProvider<String>[] args = new IDataProvider[2];
 
 					for (int i = 0; i < 2; i++)
 					{
-						IDataProvider<String> arg = DataProvider.parse(info, String.class, sm.spawn());
+						IDataProvider<String> arg = DataProvider.parse(scriptLine, info, String.class, sm.spawn());
 						if (arg == null)
 						{
-							LogUtil.error("Unable to match expression: \"" + sm.string + "\"");
+							LogUtil.error(scriptLine, "Unable to match expression: \"" + sm.string + "\"");
 							return null;
 						}
 
@@ -72,7 +73,7 @@ public class ReplaceFunction extends DataProvider<String, String>
 
 						if (sm.matchesFront(commaPattern) != (i != 1))
 						{
-							LogUtil.error("Wrong number of parameters for replace" + (m.group(1) != null?m.group(1):"") + " function: "+i);
+							LogUtil.error(scriptLine, "Wrong number of parameters for replace" + (m.group(1) != null?m.group(1):"") + " function: "+i);
 							return null;
 						}
 					}
@@ -81,7 +82,7 @@ public class ReplaceFunction extends DataProvider<String, String>
 					Matcher endMatcher = sm.matchFront(endPattern);
 					if (endMatcher == null)
 					{
-						LogUtil.error("Missing end paren: \"" + sm.string + "\"");
+						LogUtil.error(scriptLine, "Missing end paren: \"" + sm.string + "\"");
 						return null;
 					}
 

--- a/src/com/ModDamage/Expressions/Function/SubstringFunction.java
+++ b/src/com/ModDamage/Expressions/Function/SubstringFunction.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -52,17 +53,17 @@ public class SubstringFunction extends DataProvider<String, String>
 		DataProvider.register(String.class, String.class, Pattern.compile("_(substr(?:ing))?\\("), new IDataParser<String, String>()
 			{
 				@Override
-				public IDataProvider<String> parse(EventInfo info, IDataProvider<String> stringDP, Matcher m, StringMatcher sm)
+				public IDataProvider<String> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<String> stringDP, Matcher m, StringMatcher sm)
 				{
 					@SuppressWarnings("unchecked")
 					IDataProvider<Integer>[] args = new IDataProvider[2];
 
 					for (int i = 0; i < 2; i++)
 					{
-						IDataProvider<Integer> arg = DataProvider.parse(info, Integer.class, sm.spawn());
+						IDataProvider<Integer> arg = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn());
 						if (arg == null)
 						{
-							LogUtil.error("Unable to match expression: \"" + sm.string + "\"");
+							LogUtil.error(scriptLine, "Unable to match expression: \"" + sm.string + "\"");
 							return null;
 						}
 
@@ -70,7 +71,7 @@ public class SubstringFunction extends DataProvider<String, String>
 
 						if (sm.matchesFront(commaPattern) != (i != 1))
 						{
-							LogUtil.error("Wrong number of parameters for " + m.group(1) + " function: "+i);
+							LogUtil.error(scriptLine, "Wrong number of parameters for " + m.group(1) + " function: "+i);
 							return null;
 						}
 					}
@@ -79,7 +80,7 @@ public class SubstringFunction extends DataProvider<String, String>
 					Matcher endMatcher = sm.matchFront(endPattern);
 					if (endMatcher == null)
 					{
-						LogUtil.error("Missing end paren: \"" + sm.string + "\"");
+						LogUtil.error(scriptLine, "Missing end paren: \"" + sm.string + "\"");
 						return null;
 					}
 

--- a/src/com/ModDamage/Expressions/Function/ToIntFunction.java
+++ b/src/com/ModDamage/Expressions/Function/ToIntFunction.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -51,23 +52,23 @@ public class ToIntFunction implements IDataProvider<Integer>
 		DataProvider.register(Integer.class, Pattern.compile("(?:to|as)int(?:eger)?\\(", Pattern.CASE_INSENSITIVE), new BaseDataParser<Integer>()
 			{
 				@Override
-				public IDataProvider<Integer> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<Integer> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 				{
 					IDataProvider<?> valDP;
 					
-					IDataProvider<Number> numberDP = DataProvider.parse(info, Number.class, sm.spawn(), false, false, null);
+					IDataProvider<Number> numberDP = DataProvider.parse(scriptLine, info, Number.class, sm.spawn(), false, false, null);
 					if (numberDP != null)
 						valDP = numberDP;
 					else
 					{
-						IDataProvider<String> strDP = DataProvider.parse(info, String.class, sm.spawn(), false, false, null);
+						IDataProvider<String> strDP = DataProvider.parse(scriptLine, info, String.class, sm.spawn(), false, false, null);
 						if (strDP != null)
 							valDP = strDP;
 						else
 						{
-							IDataProvider<Object> objDP = DataProvider.parse(info, null, sm.spawn());
+							IDataProvider<Object> objDP = DataProvider.parse(scriptLine, info, null, sm.spawn());
 							if (objDP != null)
-								LogUtil.error("Wanted String or Number for toint(), not " + objDP.provides().getSimpleName());
+								LogUtil.error(scriptLine, "Wanted String or Number for toint(), not " + objDP.provides().getSimpleName());
 							return null;
 						}
 					}
@@ -75,7 +76,7 @@ public class ToIntFunction implements IDataProvider<Integer>
 					Matcher endMatcher = sm.matchFront(endPattern);
 					if (endMatcher == null)
 					{
-						LogUtil.error("Missing end paren: \"" + sm.string + "\"");
+						LogUtil.error(scriptLine, "Missing end paren: \"" + sm.string + "\"");
 						return null;
 					}
 

--- a/src/com/ModDamage/Expressions/InterpolatedString.java
+++ b/src/com/ModDamage/Expressions/InterpolatedString.java
@@ -10,6 +10,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.Parsing.DataProvider;
 import com.ModDamage.Parsing.IDataProvider;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.StringMatcher;
@@ -24,7 +25,7 @@ public class InterpolatedString implements IDataProvider<String>
 	private final List<InterpolatedPart> parts = new ArrayList<InterpolatedPart>();
 	private int minSize;
 	
-	public InterpolatedString(String message, EventInfo info, boolean colorize)
+	public InterpolatedString(ScriptLine scriptLine, String message, EventInfo info, boolean colorize)
 	{
 		StringMatcher sm = new StringMatcher(message);
         String part;
@@ -36,7 +37,7 @@ public class InterpolatedString implements IDataProvider<String>
 
             Matcher start = sm.matchFront(interpolationStartPattern); // already know this is true because of the while condition
 			
-			IDataProvider<String> match = DataProvider.parse(info, String.class, sm.spawn(), false, true, interpolationEndPattern);
+			IDataProvider<String> match = DataProvider.parse(scriptLine, info, String.class, sm.spawn(), false, true, interpolationEndPattern);
 			if(match == null) {
                LogUtil.warning_strong("String expression not matched!");
                 addPart(start.group());
@@ -66,7 +67,7 @@ public class InterpolatedString implements IDataProvider<String>
      * @param info The current EventInfo
      * @return The new InterpolatedString or null if parsing failed
      */
-    public static IDataProvider<String> parseWord(Pattern wordPattern, StringMatcher sm, EventInfo info) {
+    public static IDataProvider<String> parseWord(ScriptLine scriptLine, Pattern wordPattern, StringMatcher sm, EventInfo info) {
         InterpolatedString is = new InterpolatedString();
 
         Matcher m;
@@ -74,7 +75,7 @@ public class InterpolatedString implements IDataProvider<String>
         while (true) {
             m = sm.matchFront(interpolationStartPattern);
             if (m != null) {
-                IDataProvider<String> stringDP = DataProvider.parse(info, String.class, sm.spawn(), false, true, interpolationEndPattern);
+                IDataProvider<String> stringDP = DataProvider.parse(scriptLine, info, String.class, sm.spawn(), false, true, interpolationEndPattern);
                 if (stringDP == null) return null;
                 if (!sm.matchesFront(interpolationEndPattern)) return null;
                 is.addPart(stringDP);
@@ -105,11 +106,11 @@ public class InterpolatedString implements IDataProvider<String>
      * @param info The current EventInfo
      * @return The new InterpolatedString or null if parsing failed
      */
-    public static Collection<IDataProvider<String>> parseWordList(Pattern wordPattern, Pattern seperatorPattern, StringMatcher sm, EventInfo info) {
+    public static Collection<IDataProvider<String>> parseWordList(ScriptLine scriptLine, Pattern wordPattern, Pattern seperatorPattern, StringMatcher sm, EventInfo info) {
         List<IDataProvider<String>> iss = new ArrayList<IDataProvider<String>>(1);
 
         while (true) {
-            IDataProvider<String> is = parseWord(wordPattern, sm.spawn(), info);
+            IDataProvider<String> is = parseWord(scriptLine, wordPattern, sm.spawn(), info);
             if (is == null) return null;
             iss.add(is);
 

--- a/src/com/ModDamage/Expressions/List/EntitiesInWorld.java
+++ b/src/com/ModDamage/Expressions/List/EntitiesInWorld.java
@@ -12,6 +12,7 @@ import org.bukkit.World;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.ListExp;
@@ -63,7 +64,7 @@ public class EntitiesInWorld extends ListExp {
     public static void register()
     {
         DataProvider.register(List.class, Pattern.compile("(?:all\\s+)?(\\w+) in ", Pattern.CASE_INSENSITIVE), new BaseDataParser<List>() {
-            public EntitiesInWorld parse(EventInfo info, Matcher m, StringMatcher sm) {
+            public EntitiesInWorld parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm) {
                 EntityType entityType = EntityType.getElementNamed(m.group(1));
                 if (entityType == null) return null;
 
@@ -71,7 +72,7 @@ public class EntitiesInWorld extends ListExp {
                 if (sm.matchesFront(serverPattern))
                     worldDP = null;
                 else {
-                	worldDP = DataProvider.parse(info, World.class, sm.spawn());
+                	worldDP = DataProvider.parse(scriptLine, info, World.class, sm.spawn());
                 	if (worldDP == null) return null;
                 }
 

--- a/src/com/ModDamage/Expressions/List/ThingsTagged.java
+++ b/src/com/ModDamage/Expressions/List/ThingsTagged.java
@@ -16,6 +16,7 @@ import org.bukkit.entity.Entity;
 import com.ModDamage.ModDamage;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.InterpolatedString;
@@ -84,10 +85,10 @@ public class ThingsTagged extends ListExp {
     public static void register()
     {
         DataProvider.register(List.class, Pattern.compile("(players?|entit(?:y|ies)|worlds?|chunks?|loc(?:ation)?s?|blocks?) (s)?tagged ", Pattern.CASE_INSENSITIVE), new BaseDataParser<List>() {
-            public ThingsTagged parse(EventInfo info, Matcher m, StringMatcher sm) {
+            public ThingsTagged parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm) {
                 String taggableType = m.group(1).toLowerCase();
                 String tagType = m.group(2);
-                IDataProvider<String> tagName = InterpolatedString.parseWord(InterpolatedString.word, sm.spawn(), info);
+                IDataProvider<String> tagName = InterpolatedString.parseWord(scriptLine, InterpolatedString.word, sm.spawn(), info);
                 
                 
                 boolean isString;

--- a/src/com/ModDamage/Expressions/LiteralNumber.java
+++ b/src/com/ModDamage/Expressions/LiteralNumber.java
@@ -4,6 +4,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -17,7 +18,7 @@ public class LiteralNumber implements IDataProvider<Number>
 		DataProvider.register(Number.class, Pattern.compile("[0-9]+(\\.[0-9]+)?"), new BaseDataParser<Number>()
 			{
 				@Override
-				public IDataProvider<Number> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<Number> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 				{
 					if (m.group(1) != null)
 						return sm.acceptIf(new LiteralNumber(Double.parseDouble(m.group(0))));

--- a/src/com/ModDamage/Expressions/LiteralString.java
+++ b/src/com/ModDamage/Expressions/LiteralString.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -18,7 +19,7 @@ public class LiteralString implements IDataProvider<String>
 		DataProvider.register(String.class, Pattern.compile("\"((?:[^\\\\\"]+|\\\\.)*)\"|'((?:[^\\\\\']+|\\\\.)*)'"), new BaseDataParser<String>()
 			{
 				@Override
-				public IDataProvider<String> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<String> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 				{
 					String v = m.group(1);
 					if (v == null) v = m.group(2);
@@ -44,7 +45,7 @@ public class LiteralString implements IDataProvider<String>
 					}
 					
 					
-					return sm.acceptIf(new LiteralString(new InterpolatedString(sb.toString(), info, false)));
+					return sm.acceptIf(new LiteralString(new InterpolatedString(scriptLine, sb.toString(), info, false)));
 				}
 			});
 	}

--- a/src/com/ModDamage/Expressions/NestedExp.java
+++ b/src/com/ModDamage/Expressions/NestedExp.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -22,10 +23,10 @@ public class NestedExp<T> implements IDataProvider<T>
 			{
 				@Override
 				@SuppressWarnings({ "rawtypes", "unchecked" })
-				public IDataProvider<Object> parse(EventInfo info, Matcher m, StringMatcher sm)
+				public IDataProvider<Object> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 				{
 					IDataProvider<?> nestedDP;
-					nestedDP = DataProvider.parse(info, null, sm.spawn(), false, true, closeParen);
+					nestedDP = DataProvider.parse(scriptLine, info, null, sm.spawn(), false, true, closeParen);
 					
 					if (nestedDP == null || !sm.matchesFront(closeParen)) return null;
 					

--- a/src/com/ModDamage/Expressions/NumberExp.java
+++ b/src/com/ModDamage/Expressions/NumberExp.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.Function.BlockFunction;
@@ -51,10 +52,10 @@ public abstract class NumberExp<From> extends DataProvider<Number, From>
      * @param info The current EventInfo
      * @return The new Number IDataProvider or null if parsing failed
      */
-    public static IDataProvider<Number> parse(StringMatcher sm, EventInfo info) {
+    public static IDataProvider<Number> parse(ScriptLine scriptLine, StringMatcher sm, EventInfo info) {
         Matcher m = sm.matchFront(InterpolatedString.interpolationStartPattern);
         if (m != null) {
-            IDataProvider<Number> numberDP = DataProvider.parse(info, Number.class, sm.spawn(), false, true, InterpolatedString.interpolationEndPattern);
+            IDataProvider<Number> numberDP = DataProvider.parse(scriptLine, info, Number.class, sm.spawn(), false, true, InterpolatedString.interpolationEndPattern);
             if (numberDP == null) return null;
             if (!sm.matchesFront(InterpolatedString.interpolationEndPattern)) return null;
             return numberDP;

--- a/src/com/ModDamage/Expressions/StringExp.java
+++ b/src/com/ModDamage/Expressions/StringExp.java
@@ -3,6 +3,7 @@ package com.ModDamage.Expressions;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.Function.FormatFunction;
 import com.ModDamage.Expressions.Function.IndexOfFunction;
@@ -47,7 +48,7 @@ public abstract class StringExp<From> extends DataProvider<String, From>
 
 
 	@SuppressWarnings("unchecked")
-	public static List<IDataProvider<String>> getStrings(Object nestedContent, EventInfo info)
+	public static List<IDataProvider<String>> getStrings(ScriptLine scriptLine, Object nestedContent, EventInfo info)
 	{
 		List<String> strings = new ArrayList<String>();
 		if (nestedContent instanceof String)
@@ -60,7 +61,7 @@ public abstract class StringExp<From> extends DataProvider<String, From>
 		List<IDataProvider<String>> istrings = new ArrayList<IDataProvider<String>>();
 		for(String string : strings)
 		{
-			istrings.add(new InterpolatedString(string, info, true));
+			istrings.add(new InterpolatedString(scriptLine, string, info, true));
 		}
 
 		return istrings;

--- a/src/com/ModDamage/External/TabAPI/ClearTab.java
+++ b/src/com/ModDamage/External/TabAPI/ClearTab.java
@@ -44,7 +44,7 @@ public class ClearTab extends NestedRoutine
 		@Override
 		public IRoutineBuilder getNew(Matcher m, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Player> playerDP = DataProvider.parse(info, Player.class, m.group(1));
+			IDataProvider<Player> playerDP = DataProvider.parse(scriptLine, info, Player.class, m.group(1));
 			if(playerDP == null) return null;
 			
 			LogUtil.info("ClearTab: " + playerDP);

--- a/src/com/ModDamage/External/TabAPI/SetTabPriority.java
+++ b/src/com/ModDamage/External/TabAPI/SetTabPriority.java
@@ -49,11 +49,11 @@ public class SetTabPriority extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher m, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Player> playerDP = DataProvider.parse(info, Player.class, m.group(1));
+			IDataProvider<Player> playerDP = DataProvider.parse(scriptLine, info, Player.class, m.group(1));
 			if(playerDP == null) return null;
 			
 			
-			IDataProvider<Integer> priorityDP = DataProvider.parse(info, Integer.class, m.group(2)); if (priorityDP == null) return null;
+			IDataProvider<Integer> priorityDP = DataProvider.parse(scriptLine, info, Integer.class, m.group(2)); if (priorityDP == null) return null;
 			
 
 			LogUtil.info("SetTabPriority: " + playerDP + ": " + priorityDP);

--- a/src/com/ModDamage/External/TabAPI/SetTabString.java
+++ b/src/com/ModDamage/External/TabAPI/SetTabString.java
@@ -65,25 +65,25 @@ public class SetTabString extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher m, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Player> playerDP = DataProvider.parse(info, Player.class, m.group(1));
+			IDataProvider<Player> playerDP = DataProvider.parse(scriptLine, info, Player.class, m.group(1));
 			if(playerDP == null) return null;
 			
 
 			StringMatcher sm = new StringMatcher(m.group(2));
 			
-			IDataProvider<Integer> xDP = DataProvider.parse(info, Integer.class, sm.spawn()); if (xDP == null) return null;
+			IDataProvider<Integer> xDP = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn()); if (xDP == null) return null;
 			if (!sm.matchesFront(seperatorPattern)) return null;
-			IDataProvider<Integer> yDP = DataProvider.parse(info, Integer.class, sm.spawn()); if (yDP == null) return null;
+			IDataProvider<Integer> yDP = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn()); if (yDP == null) return null;
 			
 			IDataProvider<Integer> pingDP = null;
 			if (!sm.isEmpty()) {
 				if (!sm.matchesFront(seperatorPattern)) return null;
-				pingDP = DataProvider.parse(info, Integer.class, sm.spawn()); if (pingDP == null) return null;
+				pingDP = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn()); if (pingDP == null) return null;
 				
 				if (!sm.isEmpty()) return null;
 			}
 
-			IDataProvider<String> istr = DataProvider.parse(info, String.class, m.group(3));
+			IDataProvider<String> istr = DataProvider.parse(scriptLine, info, String.class, m.group(3));
 			
 
 			LogUtil.info("SetTabString: " + playerDP + " " + xDP + ", " + yDP + (pingDP == null? "" : (", " + pingDP)) + ": " + istr);

--- a/src/com/ModDamage/External/TabAPI/UpdateTab.java
+++ b/src/com/ModDamage/External/TabAPI/UpdateTab.java
@@ -44,7 +44,7 @@ public class UpdateTab extends NestedRoutine
 		@Override
 		public IRoutineBuilder getNew(Matcher m, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Player> playerDP = DataProvider.parse(info, Player.class, m.group(1));
+			IDataProvider<Player> playerDP = DataProvider.parse(scriptLine, info, Player.class, m.group(1));
 			if(playerDP == null) return null;
 			
 			LogUtil.info("UpdateTab: " + playerDP);

--- a/src/com/ModDamage/External/Vault/VaultConditional.java
+++ b/src/com/ModDamage/External/Vault/VaultConditional.java
@@ -4,6 +4,7 @@ import java.util.regex.Matcher;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.Conditionals.Conditional;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
@@ -36,9 +37,9 @@ public abstract class VaultConditional<S> extends Conditional<S>
 	public static abstract class VaultConditionalParser<S> implements IDataParser<Boolean, S>
 	{
 		@Override
-		public final IDataProvider<Boolean> parse(EventInfo info, IDataProvider<S> startDP, Matcher m, StringMatcher sm)
+		public final IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<S> startDP, Matcher m, StringMatcher sm)
 		{
-			IDataProvider<Double> amountDP = DataProvider.parse(info, Double.class, sm.spawn());
+			IDataProvider<Double> amountDP = DataProvider.parse(scriptLine, info, Double.class, sm.spawn());
 			if (amountDP == null) return null;
 			
 			return sm.acceptIf(parse(info, startDP, amountDP, m, sm));

--- a/src/com/ModDamage/External/Vault/VaultSupport.java
+++ b/src/com/ModDamage/External/Vault/VaultSupport.java
@@ -6,7 +6,6 @@ import java.util.regex.Pattern;
 import net.milkbowl.vault.chat.Chat;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
-import net.milkbowl.vault.permission.Permission;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -14,6 +13,7 @@ import org.bukkit.plugin.RegisteredServiceProvider;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -73,7 +73,7 @@ public class VaultSupport
 
 		DataProvider.register(Economy.class, Pattern.compile("economy", Pattern.CASE_INSENSITIVE), 
 				new BaseDataParser<Economy>() {
-					public IDataProvider<Economy> parse(EventInfo info, Matcher m, StringMatcher sm) {
+					public IDataProvider<Economy> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm) {
 						return sm.acceptIf(new IDataProvider<Economy>() {
 							public Economy get(EventData data) {
 								return economy;

--- a/src/com/ModDamage/External/mcMMO/AbilityConditional.java
+++ b/src/com/ModDamage/External/mcMMO/AbilityConditional.java
@@ -10,6 +10,7 @@ import com.ModDamage.Parsing.IDataParser;
 import com.ModDamage.Parsing.IDataProvider;
 import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.Conditionals.Conditional;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
@@ -100,7 +101,7 @@ public class AbilityConditional extends Conditional<Player>
 		DataProvider.register(Boolean.class, Player.class, pattern, new IDataParser<Boolean, Player>()
 			{
 				@Override
-				public IDataProvider<Boolean> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Boolean> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
 					Ability mcMMOability = null;
 					for(Ability ability : Ability.values())
@@ -108,7 +109,7 @@ public class AbilityConditional extends Conditional<Player>
 							mcMMOability = ability;
 					if(mcMMOability == null)
 					{
-						LogUtil.error("Invalid McMMO ability \"" + m.group(3) + "\"");
+						LogUtil.error(scriptLine, "Invalid McMMO ability \"" + m.group(3) + "\"");
 						return null;
 					}
 					

--- a/src/com/ModDamage/External/mcMMO/ModifySkill.java
+++ b/src/com/ModDamage/External/mcMMO/ModifySkill.java
@@ -109,11 +109,11 @@ public class ModifySkill extends NestedRoutine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Player> playerDP = DataProvider.parse(info, Player.class, matcher.group(1)); if (playerDP == null) return null;
+			IDataProvider<Player> playerDP = DataProvider.parse(scriptLine, info, Player.class, matcher.group(1)); if (playerDP == null) return null;
 			ModifyType modifyType = ModifyType.valueOf(matcher.group(2).toUpperCase());
 			SkillType skillType = SkillType.valueOf(matcher.group(3).toUpperCase());
 			
-			IDataProvider<Number> valueExp = DataProvider.parse(info, Number.class, matcher.group(4));
+			IDataProvider<Number> valueExp = DataProvider.parse(scriptLine, info, Number.class, matcher.group(4));
 			
 			return new RoutineBuilder(new ModifySkill(scriptLine, playerDP, valueExp, modifyType, skillType));
 		}

--- a/src/com/ModDamage/External/mcMMO/PlayerInt.java
+++ b/src/com/ModDamage/External/mcMMO/PlayerInt.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.SettableIntegerExp;
@@ -25,7 +26,7 @@ public class PlayerInt extends SettableIntegerExp<Player>
 				new IDataParser<Integer, Player>()
 				{
 					@Override
-					public IDataProvider<Integer> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+					public IDataProvider<Integer> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 					{
 						return sm.acceptIf(new PlayerInt(
 								playerDP,

--- a/src/com/ModDamage/External/mcMMO/PlayerSkillInt.java
+++ b/src/com/ModDamage/External/mcMMO/PlayerSkillInt.java
@@ -13,6 +13,7 @@ import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
 import com.ModDamage.Backend.ExternalPluginManager;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.NumberExp;
@@ -28,7 +29,7 @@ public class PlayerSkillInt extends NumberExp<Player>
 				new IDataParser<Number, Player>()
 				{
 					@Override
-					public IDataProvider<Number> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+					public IDataProvider<Number> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 					{
 						String skillPropStr = m.group(1);
 						String skillTypeStr = m.group(2).toUpperCase();
@@ -49,7 +50,7 @@ public class PlayerSkillInt extends NumberExp<Player>
 							}
 							catch (IllegalArgumentException e) {
 								// SkillProperty.valueOf failed to find a match
-								LogUtil.error("Unknown skill property \""+skillPropStr+"\", valid values are: "+Utils.joinBy(", ", SkillProperty.values()));
+								LogUtil.error(scriptLine, "Unknown skill property \""+skillPropStr+"\", valid values are: "+Utils.joinBy(", ", SkillProperty.values()));
 								return null;
 							}
 
@@ -59,7 +60,7 @@ public class PlayerSkillInt extends NumberExp<Player>
 							}
 							catch (IllegalArgumentException e) {
 								// SkillType.valueOf failed to find a match
-								LogUtil.error("Unknown skill type \""+skillTypeStr+"\", valid values are: "+Utils.joinBy(", ", SkillType.values()));
+								LogUtil.error(scriptLine, "Unknown skill type \""+skillTypeStr+"\", valid values are: "+Utils.joinBy(", ", SkillType.values()));
 								return null;
 							}
 
@@ -70,7 +71,7 @@ public class PlayerSkillInt extends NumberExp<Player>
 						}
 						catch (NoClassDefFoundError e) {
 							if (ExternalPluginManager.getMcMMOPlugin() == null)
-								LogUtil.error("You need mcMMO to use the skill variables.");
+								LogUtil.error(scriptLine, "You need mcMMO to use the skill variables.");
 							else
 								LogUtil.error("McMMO has changed. Please notify the ModDamage developers.");
 						}

--- a/src/com/ModDamage/Parsing/BaseDataParser.java
+++ b/src/com/ModDamage/Parsing/BaseDataParser.java
@@ -3,16 +3,17 @@ package com.ModDamage.Parsing;
 import java.util.regex.Matcher;
 
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventInfo;
 
 public abstract class BaseDataParser<T> implements IDataParser<T, Object>
 {
 	@Override
-	public final IDataProvider<T> parse(EventInfo info, IDataProvider<Object> nullDP, Matcher m, StringMatcher sm)
+	public final IDataProvider<T> parse(ScriptLine line, EventInfo info, IDataProvider<Object> nullDP, Matcher m, StringMatcher sm)
 	{
 		if (nullDP != null) return null;
-		return parse(info, m, sm);
+		return parse(line, info, m, sm);
 	}
 	
-	public abstract IDataProvider<T> parse(EventInfo info, Matcher m, StringMatcher sm);
+	public abstract IDataProvider<T> parse(ScriptLine line, EventInfo info, Matcher m, StringMatcher sm);
 }

--- a/src/com/ModDamage/Parsing/FunctionParser.java
+++ b/src/com/ModDamage/Parsing/FunctionParser.java
@@ -5,6 +5,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventInfo;
 
 @SuppressWarnings("rawtypes")
@@ -21,14 +22,14 @@ public abstract class FunctionParser<T, S> implements IDataParser<T, S> {
 
     @SuppressWarnings("unchecked")
 	@Override
-    public IDataProvider<T> parse(EventInfo info, IDataProvider<S> startDP, Matcher m, StringMatcher sm) {
+    public IDataProvider<T> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<S> startDP, Matcher m, StringMatcher sm) {
         IDataProvider[] args = new IDataProvider[parameters.length];
 
         if (!sm.matchesFront(startParenPattern)) return null;
         for (int i = 0; i < parameters.length; i++) {
             if (i > 0 && !sm.matchesFront(commaPattern)) return null;
 
-            args[i] = DataProvider.parse(info, parameters[i], sm.spawn(), false, true, (i == parameters.length-1)? endParenPattern : commaPattern);
+            args[i] = DataProvider.parse(scriptLine, info, parameters[i], sm.spawn(), false, true, (i == parameters.length-1)? endParenPattern : commaPattern);
             if (args[i] == null) return null;
         }
         if (!sm.matchesFront(endParenPattern)) return null;

--- a/src/com/ModDamage/Parsing/IDataParser.java
+++ b/src/com/ModDamage/Parsing/IDataParser.java
@@ -3,9 +3,10 @@ package com.ModDamage.Parsing;
 import java.util.regex.Matcher;
 
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventInfo;
 
 public interface IDataParser<T, S>
 {
-	IDataProvider<T> parse(EventInfo info, IDataProvider<S> startDP, Matcher m, StringMatcher sm);
+	IDataProvider<T> parse(ScriptLine line, EventInfo info, IDataProvider<S> startDP, Matcher m, StringMatcher sm);
 }

--- a/src/com/ModDamage/Parsing/Property/Property.java
+++ b/src/com/ModDamage/Parsing/Property/Property.java
@@ -2,6 +2,7 @@ package com.ModDamage.Parsing.Property;
 
 
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.IDataParser;
@@ -83,7 +84,7 @@ public abstract class Property<T, S> {
     public class Parser implements IDataParser<T, S>
     {
         @Override
-        public IDataProvider<T> parse(EventInfo info, IDataProvider<S> startDP, Matcher m, StringMatcher sm) {
+        public IDataProvider<T> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<S> startDP, Matcher m, StringMatcher sm) {
             return provider(startDP);
         }
     }

--- a/src/com/ModDamage/Parsing/SettableDataProvider.java
+++ b/src/com/ModDamage/Parsing/SettableDataProvider.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 
@@ -25,24 +26,24 @@ public abstract class SettableDataProvider<T, S> extends DataProvider<T, S> impl
 	public abstract void set(S start, EventData data, T value) throws BailException;
 	
 	
-	public static <T> ISettableDataProvider<T> parse(EventInfo info, Class<T> want, String s)
+	public static <T> ISettableDataProvider<T> parse(ScriptLine scriptLine, EventInfo info, Class<T> want, String s)
 	{
-		return parse(info, want, s, true, true);
+		return parse(scriptLine, info, want, s, true, true);
 	}
 	
-	public static <T> ISettableDataProvider<T> parse(EventInfo info, Class<T> want, String s, boolean finish, boolean complain)
+	public static <T> ISettableDataProvider<T> parse(ScriptLine scriptLine, EventInfo info, Class<T> want, String s, boolean finish, boolean complain)
 	{
-		return parse(info, want, new StringMatcher(s), finish, complain, null);
+		return parse(scriptLine, info, want, new StringMatcher(s), finish, complain, null);
 	}
 
-	public static <T> ISettableDataProvider<T> parse(EventInfo info, Class<T> want, StringMatcher sm)
+	public static <T> ISettableDataProvider<T> parse(ScriptLine scriptLine, EventInfo info, Class<T> want, StringMatcher sm)
 	{
-		return parse(info, want, sm, false, true, null);
+		return parse(scriptLine, info, want, sm, false, true, null);
 	}
 	
-	public static <T> ISettableDataProvider<T> parse(EventInfo info, Class<T> want, StringMatcher sm, boolean finish, boolean complain, Pattern endPattern)
+	public static <T> ISettableDataProvider<T> parse(ScriptLine scriptLine, EventInfo info, Class<T> want, StringMatcher sm, boolean finish, boolean complain, Pattern endPattern)
 	{
-		IDataProvider<T> dp = DataProvider.parse(info, want, sm, finish, complain, endPattern);
+		IDataProvider<T> dp = DataProvider.parse(scriptLine, info, want, sm, finish, complain, endPattern);
 		if (dp == null) return null;
 		
 		if (!(dp instanceof ISettableDataProvider) || !((ISettableDataProvider<?>)dp).isSettable())

--- a/src/com/ModDamage/Properties/InventoryProps.java
+++ b/src/com/ModDamage/Properties/InventoryProps.java
@@ -13,6 +13,7 @@ import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
 import com.ModDamage.Backend.InventorySlot;
 import com.ModDamage.Backend.ItemHolder;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.DataProvider;
@@ -129,7 +130,7 @@ public class InventoryProps
 
         DataProvider.register(Integer.class, InventoryView.class, Pattern.compile("_("+ Utils.joinBy("|", InventoryView.Property.values()) + ")"),
                 new IDataParser<Integer, InventoryView>() {
-                    public IDataProvider<Integer> parse(EventInfo info, IDataProvider<InventoryView> startDP, Matcher m, StringMatcher sm) {
+                    public IDataProvider<Integer> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<InventoryView> startDP, Matcher m, StringMatcher sm) {
                         final InventoryView.Property property = InventoryView.Property.valueOf(m.group(1).toUpperCase());
                         return new SettableDataProvider<Integer, InventoryView>(InventoryView.class, startDP) {
                             public Integer get(InventoryView view, EventData data) {

--- a/src/com/ModDamage/Properties/ScoreboardProps.java
+++ b/src/com/ModDamage/Properties/ScoreboardProps.java
@@ -12,6 +12,7 @@ import org.bukkit.scoreboard.Team;
 import com.ModDamage.Scoreboards;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.InterpolatedString;
@@ -57,7 +58,7 @@ public class ScoreboardProps
         SettableDataProvider.register(Team.class, OfflinePlayer.class, Pattern.compile("_team", Pattern.CASE_INSENSITIVE), new IDataParser<Team, OfflinePlayer>()
 			{
 				@Override
-				public IDataProvider<Team> parse(EventInfo info, final IDataProvider<OfflinePlayer> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Team> parse(ScriptLine scriptLine, EventInfo info, final IDataProvider<OfflinePlayer> playerDP, Matcher m, StringMatcher sm)
 				{
 					final IDataProvider<Scoreboard> scoreboardDP = Scoreboards.getCurrent(info);
 					
@@ -171,11 +172,11 @@ public class ScoreboardProps
         DataProvider.register(Integer.class, OfflinePlayer.class, Pattern.compile("objectivenamed"), new IDataParser<Integer, OfflinePlayer>()
 			{
 				@Override
-				public IDataProvider<Integer> parse(EventInfo info, final IDataProvider<OfflinePlayer> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<Integer> parse(ScriptLine scriptLine, EventInfo info, final IDataProvider<OfflinePlayer> playerDP, Matcher m, StringMatcher sm)
 				{
 					final IDataProvider<Scoreboard> scoreboardDP = Scoreboards.getCurrent(info);
 					
-					final IDataProvider<String> nameDP = InterpolatedString.parseWord(InterpolatedString.word, sm.spawn(), info);
+					final IDataProvider<String> nameDP = InterpolatedString.parseWord(scriptLine, InterpolatedString.word, sm.spawn(), info);
 					if (nameDP == null) return null;
 
 					return new ISettableDataProvider<Integer>() {

--- a/src/com/ModDamage/Properties/ServerProps.java
+++ b/src/com/ModDamage/Properties/ServerProps.java
@@ -7,6 +7,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Server;
 
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -21,7 +22,7 @@ public class ServerProps
 	{
 		DataProvider.register(Server.class, Pattern.compile("server", Pattern.CASE_INSENSITIVE), 
 				new BaseDataParser<Server>() {
-					public IDataProvider<Server> parse(EventInfo info, Matcher m, StringMatcher sm)
+					public IDataProvider<Server> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 					{
 						return sm.acceptIf(new IDataProvider<Server>() {
 							public Server get(EventData data) {

--- a/src/com/ModDamage/Routines/AddPotionEffect.java
+++ b/src/com/ModDamage/Routines/AddPotionEffect.java
@@ -59,20 +59,20 @@ public class AddPotionEffect extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{ 
-			IDataProvider<LivingEntity> livingDP = DataProvider.parse(info, LivingEntity.class, matcher.group(1));
+			IDataProvider<LivingEntity> livingDP = DataProvider.parse(scriptLine, info, LivingEntity.class, matcher.group(1));
 			if (livingDP == null) return null; 
 			
 			PotionEffectType type = PotionEffectType.getByName(matcher.group(2).toUpperCase());
 			if (type == null)
 			{
-				LogUtil.error("Unknown potion effect type '"+matcher.group(2)+"'");
+				LogUtil.error(scriptLine, "Unknown potion effect type '"+matcher.group(2)+"'");
 				return null;
 			}
 			
 			StringMatcher sm = new StringMatcher(matcher.group(3));
-			IDataProvider<Integer> duration = DataProvider.parse(info, Integer.class, sm.spawn()); if (duration == null) return null;
+			IDataProvider<Integer> duration = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn()); if (duration == null) return null;
 			if (!sm.matchesFront(dotPattern)) return null;
-			IDataProvider<Integer> amplifier = DataProvider.parse(info, Integer.class, sm.spawn()); if (amplifier == null) return null;
+			IDataProvider<Integer> amplifier = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn()); if (amplifier == null) return null;
 			if (!sm.isEmpty()) return null;
 			
 			LogUtil.info("AddPotionEffect: to " + livingDP + ", " + type.getName() + ", " + duration + ", " + amplifier);

--- a/src/com/ModDamage/Routines/Cancel.java
+++ b/src/com/ModDamage/Routines/Cancel.java
@@ -40,7 +40,7 @@ public class Cancel extends NestedRoutine
 			ISettableDataProvider<Boolean> cancelDP = info.get(Boolean.class, "cancelled", false);
 			if(cancelDP == null)
 			{
-				LogUtil.error("This event cannot be cancelled.");
+				LogUtil.error(scriptLine, "This event cannot be cancelled.");
 				return null;
 			}
 			

--- a/src/com/ModDamage/Routines/ClearEnchantments.java
+++ b/src/com/ModDamage/Routines/ClearEnchantments.java
@@ -42,7 +42,7 @@ public class ClearEnchantments extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<EnchantmentsRef> enchantmentsDP = DataProvider.parse(info, EnchantmentsRef.class, "enchantments");
+			IDataProvider<EnchantmentsRef> enchantmentsDP = DataProvider.parse(scriptLine, info, EnchantmentsRef.class, "enchantments");
 			if(enchantmentsDP == null) return null;
 			
 			LogUtil.info("Clear Enchantments");

--- a/src/com/ModDamage/Routines/Despawn.java
+++ b/src/com/ModDamage/Routines/Despawn.java
@@ -41,7 +41,7 @@ public class Despawn extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{ 
-			IDataProvider<Entity> entityDP = DataProvider.parse(info, Entity.class, matcher.group(1));
+			IDataProvider<Entity> entityDP = DataProvider.parse(scriptLine, info, Entity.class, matcher.group(1));
 			if (entityDP == null) return null;
 			
 			LogUtil.info("Despawn: " + entityDP);

--- a/src/com/ModDamage/Routines/EntityHeal.java
+++ b/src/com/ModDamage/Routines/EntityHeal.java
@@ -49,10 +49,10 @@ public class EntityHeal extends Routine
 		{
 			String name = matcher.group(1).toLowerCase();
 			
-			IDataProvider<LivingEntity> livingDP = DataProvider.parse(info, LivingEntity.class, name);
+			IDataProvider<LivingEntity> livingDP = DataProvider.parse(scriptLine, info, LivingEntity.class, name);
             if (livingDP == null) return null;
             
-			IDataProvider<Number> heal_amount = DataProvider.parse(info, Number.class, matcher.group(2));
+			IDataProvider<Number> heal_amount = DataProvider.parse(scriptLine, info, Number.class, matcher.group(2));
             if (heal_amount == null) return null;
 
             LogUtil.info("Heal "+livingDP+" by "+heal_amount);

--- a/src/com/ModDamage/Routines/EntityHurt.java
+++ b/src/com/ModDamage/Routines/EntityHurt.java
@@ -68,14 +68,14 @@ public class EntityHurt extends Routine
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
 			String name = matcher.group(1).toLowerCase();
-			IDataProvider<LivingEntity> livingDP = DataProvider.parse(info, LivingEntity.class, name);
+			IDataProvider<LivingEntity> livingDP = DataProvider.parse(scriptLine, info, LivingEntity.class, name);
 			if (livingDP == null) return null;
 
 
             IDataProvider<Entity> entityOtherDP;
             if (matcher.group(2) != null)
             {
-                entityOtherDP = DataProvider.parse(info, Entity.class, matcher.group(2));
+                entityOtherDP = DataProvider.parse(scriptLine, info, Entity.class, matcher.group(2));
 
                 if (entityOtherDP == null) return null;
             }
@@ -85,13 +85,13 @@ public class EntityHurt extends Routine
                 entityOtherDP = info.get(Entity.class, otherName);
                 if (entityOtherDP == null)
                 {
-                	LogUtil.error("The entity '"+livingDP+"' doesn't have a natural opposite. Use .hurt.from.{entity}");
+                	LogUtil.error(scriptLine, "The entity '"+livingDP+"' doesn't have a natural opposite. Use .hurt.from.{entity}");
                     return null;
                 }
             }
 
 
-			IDataProvider<Number> hurt_amount = DataProvider.parse(info, Number.class, matcher.group(3));
+			IDataProvider<Number> hurt_amount = DataProvider.parse(scriptLine, info, Number.class, matcher.group(3));
 			if (hurt_amount == null) return null;
 			
 			

--- a/src/com/ModDamage/Routines/EntityUnknownHurt.java
+++ b/src/com/ModDamage/Routines/EntityUnknownHurt.java
@@ -52,11 +52,11 @@ public class EntityUnknownHurt extends Routine
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
 			String name = matcher.group(1).toLowerCase();
-			IDataProvider<LivingEntity> livingDP = DataProvider.parse(info, LivingEntity.class, name);
+			IDataProvider<LivingEntity> livingDP = DataProvider.parse(scriptLine, info, LivingEntity.class, name);
             if(livingDP == null) return null;
 
 
-			IDataProvider<Number> hurt_amount = DataProvider.parse(info, Number.class, matcher.group(2));
+			IDataProvider<Number> hurt_amount = DataProvider.parse(scriptLine, info, Number.class, matcher.group(2));
             if (hurt_amount == null) return null;
             
             LogUtil.info("UnknownHurt " + livingDP + " by " + hurt_amount);

--- a/src/com/ModDamage/Routines/Explode.java
+++ b/src/com/ModDamage/Routines/Explode.java
@@ -48,10 +48,10 @@ public class Explode extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Location> locDP = DataProvider.parse(info, Location.class, matcher.group(1));
+			IDataProvider<Location> locDP = DataProvider.parse(scriptLine, info, Location.class, matcher.group(1));
 			if (locDP == null) return null;
 
-			IDataProvider<Number> strength = DataProvider.parse(info, Number.class, matcher.group(2));
+			IDataProvider<Number> strength = DataProvider.parse(scriptLine, info, Number.class, matcher.group(2));
 			if(strength == null) return null;
 
 			LogUtil.info("Explode at " + locDP + " with strength " + strength);

--- a/src/com/ModDamage/Routines/Lightning.java
+++ b/src/com/ModDamage/Routines/Lightning.java
@@ -47,7 +47,7 @@ public class Lightning extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{ 
-			IDataProvider<Location> locDP = DataProvider.parse(info, Location.class, matcher.group(1));
+			IDataProvider<Location> locDP = DataProvider.parse(scriptLine, info, Location.class, matcher.group(1));
 			if (locDP == null) return null;
 
             boolean effect = matcher.group(2) != null;

--- a/src/com/ModDamage/Routines/Nested/Command.java
+++ b/src/com/ModDamage/Routines/Nested/Command.java
@@ -46,7 +46,7 @@ public class Command extends NestedRoutine
 	
 	private abstract static class CommandTarget
 	{
-		protected static CommandTarget match(String key, EventInfo info)
+		protected static CommandTarget match(ScriptLine scriptLine, String key, EventInfo info)
 		{
 			if (key.equalsIgnoreCase("console"))
 				return new CommandTarget()
@@ -62,7 +62,7 @@ public class Command extends NestedRoutine
 					};
 			
 			{
-				final IDataProvider<Entity> entityDP = DataProvider.parse(info, Entity.class, key);
+				final IDataProvider<Entity> entityDP = DataProvider.parse(scriptLine, info, Entity.class, key);
 				if(entityDP == null) return null;
 				return new CommandTarget()
 				{
@@ -101,14 +101,14 @@ public class Command extends NestedRoutine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			CommandTarget commandTarget = CommandTarget.match(matcher.group(1), info);
+			CommandTarget commandTarget = CommandTarget.match(scriptLine, matcher.group(1), info);
 			if(commandTarget == null)
 			{
-				LogUtil.error("Bad command target: "+matcher.group(1));
+				LogUtil.error(scriptLine, "Bad command target: "+matcher.group(1));
 				return null;
 			}
 			
-			Collection<IDataProvider<String>> commands = CommandAliaser.match(matcher.group(2), info);
+			Collection<IDataProvider<String>> commands = CommandAliaser.match(scriptLine, matcher.group(2), info);
 			if (commands == null)
 			{
 				LogUtil.error("This command form can only be used for command aliases. Please use the following instead.");
@@ -134,7 +134,7 @@ public class Command extends NestedRoutine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			CommandTarget commandTarget = CommandTarget.match(matcher.group(1), info);
+			CommandTarget commandTarget = CommandTarget.match(scriptLine, matcher.group(1), info);
 			if(commandTarget == null) return null;
 			
 
@@ -167,7 +167,7 @@ public class Command extends NestedRoutine
 
 		public void addString(String str)
 		{
-			IDataProvider<String> cmdDP = DataProvider.parse(info, String.class, str);
+			IDataProvider<String> cmdDP = DataProvider.parse(scriptLine, info, String.class, str);
 			if (cmdDP != null) {
 				commands.add(cmdDP);
 				LogUtil.info(cmdDP.toString());

--- a/src/com/ModDamage/Routines/Nested/Delay.java
+++ b/src/com/ModDamage/Routines/Nested/Delay.java
@@ -41,7 +41,7 @@ public class Delay extends NestedRoutine
 		{
 			if(!matcher.matches()) return null;
 
-			IDataProvider<Integer> numberMatch = DataProvider.parse(info, Integer.class, matcher.group(1));
+			IDataProvider<Integer> numberMatch = DataProvider.parse(scriptLine, info, Integer.class, matcher.group(1));
 			
 			LogUtil.info("Delay: \"" + numberMatch + "\"");
 			if (numberMatch == null) return null;

--- a/src/com/ModDamage/Routines/Nested/DropItem.java
+++ b/src/com/ModDamage/Routines/Nested/DropItem.java
@@ -93,14 +93,14 @@ public class DropItem extends NestedRoutine
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
 			String name = matcher.group(1).toLowerCase();
-			IDataProvider<Location> locationDP = DataProvider.parse(info, Location.class, name);
+			IDataProvider<Location> locationDP = DataProvider.parse(scriptLine, info, Location.class, name);
 			if (locationDP == null) return null;
-			Collection<ModDamageItemStack> items = ItemAliaser.match(matcher.group(2), info);
+			Collection<ModDamageItemStack> items = ItemAliaser.match(scriptLine, matcher.group(2), info);
 			if(items == null || items.isEmpty()) return null;
 			
 			IDataProvider<? extends Number> quantity;
 			if (matcher.group(3) != null)
-				quantity = DataProvider.parse(info, Integer.class, matcher.group(3));
+				quantity = DataProvider.parse(scriptLine, info, Integer.class, matcher.group(3));
 			else
 				quantity = new LiteralNumber(1);
 

--- a/src/com/ModDamage/Routines/Nested/EntityItemAction.java
+++ b/src/com/ModDamage/Routines/Nested/EntityItemAction.java
@@ -119,14 +119,14 @@ public class EntityItemAction extends NestedRoutine
 			String name = matcher.group(1).toLowerCase();
             String action = matcher.group(2).toUpperCase();
 
-			IDataProvider<HumanEntity> humanDP = DataProvider.parse(info, HumanEntity.class, name); if (humanDP == null) return null;
-			Collection<ModDamageItemStack> items = ItemAliaser.match(matcher.group(3), info);
+			IDataProvider<HumanEntity> humanDP = DataProvider.parse(scriptLine, info, HumanEntity.class, name); if (humanDP == null) return null;
+			Collection<ModDamageItemStack> items = ItemAliaser.match(scriptLine, matcher.group(3), info);
 			if(items == null || items.isEmpty()) return null;
 			
 			
 			IDataProvider<? extends Number> quantity;
 			if (matcher.group(4) != null)
-				quantity = DataProvider.parse(info, Integer.class, matcher.group(4));
+				quantity = DataProvider.parse(scriptLine, info, Integer.class, matcher.group(4));
 			else
 				quantity = new LiteralNumber(1);
 

--- a/src/com/ModDamage/Routines/Nested/For.java
+++ b/src/com/ModDamage/Routines/Nested/For.java
@@ -88,13 +88,13 @@ public class For extends NestedRoutine
 			
 			StringMatcher sm = new StringMatcher(matcher.group(2));
 			
-			IDataProvider<Number> fromDP = DataProvider.parse(info, Number.class, sm.spawn(), false, true, toPattern);
+			IDataProvider<Number> fromDP = DataProvider.parse(scriptLine, info, Number.class, sm.spawn(), false, true, toPattern);
 			if (fromDP == null) return null;
 			
 			if (!sm.matchesFront(toPattern))
 				return null;
 			
-			IDataProvider<Number> toDP = DataProvider.parse(info, Number.class, sm.spawn(), false, true, byPattern);
+			IDataProvider<Number> toDP = DataProvider.parse(scriptLine, info, Number.class, sm.spawn(), false, true, byPattern);
 			if (toDP == null) return null;
 			
 			if (!sm.isEmpty() && !sm.matchesFront(toPattern))
@@ -105,7 +105,7 @@ public class For extends NestedRoutine
 				byDP = new LiteralNumber(1);
 			}
 			else {
-				byDP = DataProvider.parse(info, Number.class, sm.spawn(), true, true, null);
+				byDP = DataProvider.parse(scriptLine, info, Number.class, sm.spawn(), true, true, null);
 				if (byDP == null) return null;
 			}
 			

--- a/src/com/ModDamage/Routines/Nested/Foreach.java
+++ b/src/com/ModDamage/Routines/Nested/Foreach.java
@@ -54,7 +54,7 @@ public class Foreach extends NestedRoutine
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
 			String name = matcher.group(2);
-			IDataProvider<List> listDP = DataProvider.parse(info, List.class, matcher.group(1));
+			IDataProvider<List> listDP = DataProvider.parse(scriptLine, info, List.class, matcher.group(1));
 			if (listDP == null) return null;
 
 			ListExp alistDP = (ListExp) listDP;

--- a/src/com/ModDamage/Routines/Nested/If.java
+++ b/src/com/ModDamage/Routines/Nested/If.java
@@ -63,7 +63,7 @@ public class If extends NestedRoutine
 			IDataProvider<Boolean> conditional;
 			if (matcher.group(3) == null)
 			{
-				conditional = DataProvider.parse(info, Boolean.class, matcher.group(2));
+				conditional = DataProvider.parse(scriptLine, info, Boolean.class, matcher.group(2));
 				if (conditional == null) return null;
 			}
 			else

--- a/src/com/ModDamage/Routines/Nested/Knockback.java
+++ b/src/com/ModDamage/Routines/Nested/Knockback.java
@@ -72,13 +72,13 @@ public class Knockback extends NestedRoutine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Entity> entityDP = DataProvider.parse(info, Entity.class, matcher.group(1));
+			IDataProvider<Entity> entityDP = DataProvider.parse(scriptLine, info, Entity.class, matcher.group(1));
 			if (entityDP == null) return null;
 			
 			boolean explicitFrom = matcher.group(2) != null;
 			IDataProvider<Location> fromDP = null;
 			if (explicitFrom) {
-                fromDP = DataProvider.parse(info, Location.class, matcher.group(2));
+                fromDP = DataProvider.parse(scriptLine, info, Location.class, matcher.group(2));
 				if (fromDP == null)
 					return null;
 			} else {
@@ -87,7 +87,7 @@ public class Knockback extends NestedRoutine
                     fromDP = DataProvider.transform(Location.class, otherEntityDP, info, false);
 				if (fromDP == null)
 				{
-					LogUtil.error("The entity '"+entityDP+"' doesn't have a natural opposite, so you need to specify one using '"+matcher.group()+".from.{entity}'");
+					LogUtil.error(scriptLine, "The entity '"+entityDP+"' doesn't have a natural opposite, so you need to specify one using '"+matcher.group()+".from.{entity}'");
 					return null;
 				}
 			}

--- a/src/com/ModDamage/Routines/Nested/LaunchProjectile.java
+++ b/src/com/ModDamage/Routines/Nested/LaunchProjectile.java
@@ -139,25 +139,25 @@ public class LaunchProjectile extends NestedRoutine
 			if (launchType == null) return null;
 			if (!Projectile.class.isAssignableFrom(launchType.myClass) || launchType == EntityType.POTION)
 			{
-				LogUtil.error("Not a launchable projectile: "+matcher.group(2));
+				LogUtil.error(scriptLine, "Not a launchable projectile: "+matcher.group(2));
 				return null;
 			}
 			
 			if (matcher.group(1) == null && matcher.group(3) == null)
 			{
-				LogUtil.error("Either a shooter or a launch location must be specified!");
+				LogUtil.error(scriptLine, "Either a shooter or a launch location must be specified!");
 				return null;
 			}
 			
 			IDataProvider<LivingEntity> livingDP = null;
 			if (matcher.group(1) != null) {
-				livingDP = DataProvider.parse(info, LivingEntity.class, matcher.group(1));
+				livingDP = DataProvider.parse(scriptLine, info, LivingEntity.class, matcher.group(1));
 				if (livingDP == null) return null;
 			}
 
 			IDataProvider<Location> locDP = null;
 			if (matcher.group(3) != null) {
-				locDP = DataProvider.parse(info, Location.class, matcher.group(3));
+				locDP = DataProvider.parse(scriptLine, info, Location.class, matcher.group(3));
 				if (locDP == null) return null;
 			}
 

--- a/src/com/ModDamage/Routines/Nested/LogMessage.java
+++ b/src/com/ModDamage/Routines/Nested/LogMessage.java
@@ -86,7 +86,7 @@ public class LogMessage extends NestedRoutine
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
 			StringMatcher sm = new StringMatcher(matcher.group(1));
-			IDataProvider<String> logNameDP = InterpolatedString.parseWord(InterpolatedString.word, sm, info);
+			IDataProvider<String> logNameDP = InterpolatedString.parseWord(scriptLine, InterpolatedString.word, sm, info);
 			if (logNameDP == null) return null;
 
 			
@@ -121,7 +121,7 @@ public class LogMessage extends NestedRoutine
 		
 		public void addString(String str)
 		{
-			IDataProvider<String> msgDP = DataProvider.parse(info, String.class, str);
+			IDataProvider<String> msgDP = DataProvider.parse(scriptLine, info, String.class, str);
 			if (msgDP != null) {
 				messages.add(msgDP);
 				LogUtil.info(msgDP.toString());

--- a/src/com/ModDamage/Routines/Nested/Message.java
+++ b/src/com/ModDamage/Routines/Nested/Message.java
@@ -50,7 +50,7 @@ public class Message extends Routine
 	
 	private abstract static class MessageTarget
 	{
-		protected static MessageTarget match(StringMatcher sm, EventInfo info)
+		protected static MessageTarget match(ScriptLine scriptLine, StringMatcher sm, EventInfo info)
 		{
 			StringMatcher sm2 = sm.spawn();
 			if (sm2.matchesFront("console") && targetEndPattern.matcher(sm2.string).lookingAt()) {
@@ -87,7 +87,7 @@ public class Message extends Routine
 			}
 			// try a world first
 			{
-				final IDataProvider<World> worldDP = DataProvider.parse(info, World.class, sm.spawn(), false, false, targetEndPattern);
+				final IDataProvider<World> worldDP = DataProvider.parse(scriptLine, info, World.class, sm.spawn(), false, false, targetEndPattern);
 				if (worldDP != null) {
 					return new MessageTarget()
 						{
@@ -109,7 +109,7 @@ public class Message extends Routine
 			}
 			// otherwise try to find a player
 			{
-				final IDataProvider<Player> playerDP = DataProvider.parse(info, Player.class, sm.spawn(), false, true, targetEndPattern);
+				final IDataProvider<Player> playerDP = DataProvider.parse(scriptLine, info, Player.class, sm.spawn(), false, true, targetEndPattern);
 				if(playerDP != null) {
 					return new MessageTarget()
 					{
@@ -148,17 +148,17 @@ public class Message extends Routine
 		{
 			StringMatcher sm = new StringMatcher(matcher.group(1));
 			
-			MessageTarget messageTarget = MessageTarget.match(sm, info);
+			MessageTarget messageTarget = MessageTarget.match(scriptLine, sm, info);
 			if(messageTarget == null)
 			{
-				LogUtil.error("Bad message target: "+matcher.group(1));
+				LogUtil.error(scriptLine, "Bad message target: "+matcher.group(1));
 				return null;
 			}
 			
 			Matcher targetEnd = sm.matchFront(targetEndPattern);
 			
 			if (targetEnd.group(1) != null) {
-				Collection<IDataProvider<String>> messages = MessageAliaser.match(targetEnd.group(1), info);
+				Collection<IDataProvider<String>> messages = MessageAliaser.match(scriptLine, targetEnd.group(1), info);
 				if (messages == null)
 				{
 //					LogUtil.error("This message form can only be used for message aliases. Please use the following instead.");
@@ -209,7 +209,7 @@ public class Message extends Routine
 		
 		public void addString(String str)
 		{
-			IDataProvider<String> msgDP = DataProvider.parse(info, String.class, str);
+			IDataProvider<String> msgDP = DataProvider.parse(scriptLine, info, String.class, str);
 			if (msgDP != null) {
 				if (msgDP instanceof LiteralString) {
 					((LiteralString) msgDP).colorize();

--- a/src/com/ModDamage/Routines/Nested/Nearby.java
+++ b/src/com/ModDamage/Routines/Nested/Nearby.java
@@ -98,9 +98,9 @@ public class Nearby extends NestedRoutine
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
 			boolean nearest = matcher.group(1).equalsIgnoreCase("est");
-			IDataProvider<Entity> entityDP = DataProvider.parse(info, Entity.class, matcher.group(2)); if (entityDP == null) return null;
+			IDataProvider<Entity> entityDP = DataProvider.parse(scriptLine, info, Entity.class, matcher.group(2)); if (entityDP == null) return null;
 			EntityType element = EntityType.getElementNamed(matcher.group(3)); if (element == null) return null;
-			IDataProvider<Integer> radius = DataProvider.parse(info, Integer.class, matcher.group(4)); if (radius == null) return null;
+			IDataProvider<Integer> radius = DataProvider.parse(scriptLine, info, Integer.class, matcher.group(4)); if (radius == null) return null;
 
 			LogUtil.info("Near" + (nearest? "est" : "by") + ": " + entityDP + ", " + element + ", " + radius);
 

--- a/src/com/ModDamage/Routines/Nested/PlayerChat.java
+++ b/src/com/ModDamage/Routines/Nested/PlayerChat.java
@@ -54,7 +54,7 @@ public class PlayerChat extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Player> playerDP = DataProvider.parse(info, Player.class, matcher.group(1));
+			IDataProvider<Player> playerDP = DataProvider.parse(scriptLine, info, Player.class, matcher.group(1));
 			if(playerDP == null) return null;
 
 
@@ -87,7 +87,7 @@ public class PlayerChat extends Routine
 		
 		public void addString(String str)
 		{
-			IDataProvider<String> msgDP = DataProvider.parse(info, String.class, str);
+			IDataProvider<String> msgDP = DataProvider.parse(scriptLine, info, String.class, str);
 			if (msgDP != null) {
 				if (msgDP instanceof LiteralString) {
 					((LiteralString) msgDP).colorize();

--- a/src/com/ModDamage/Routines/Nested/Spawn.java
+++ b/src/com/ModDamage/Routines/Nested/Spawn.java
@@ -66,7 +66,7 @@ public class Spawn extends NestedRoutine
 				LogUtil.error("Cannot spawn "+matcher.group(2));
 				return null;
 			}
-			IDataProvider<Location> locDP = DataProvider.parse(info, Location.class, matcher.group(1));
+			IDataProvider<Location> locDP = DataProvider.parse(scriptLine, info, Location.class, matcher.group(1));
             if (locDP == null) return null;
 
             LogUtil.info("Spawn "+spawnType+" at "+locDP);

--- a/src/com/ModDamage/Routines/Nested/SwitchRoutine.java
+++ b/src/com/ModDamage/Routines/Nested/SwitchRoutine.java
@@ -128,7 +128,7 @@ public class SwitchRoutine extends NestedRoutine
 		@Override
 		public ScriptLineHandler handleLine(ScriptLine line, boolean hasChildren)
 		{
-			IDataProvider<Boolean> matchedCase = DataProvider.parse(info, Boolean.class, switchType + "." + line.line);
+			IDataProvider<Boolean> matchedCase = DataProvider.parse(scriptLine, info, Boolean.class, switchType + "." + line.line);
 			if(matchedCase == null) return null;
 			
 			Routines routines = new Routines();

--- a/src/com/ModDamage/Routines/Nested/While.java
+++ b/src/com/ModDamage/Routines/Nested/While.java
@@ -43,7 +43,7 @@ public class While extends NestedRoutine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Boolean> conditional = DataProvider.parse(info, Boolean.class, matcher.group(1));
+			IDataProvider<Boolean> conditional = DataProvider.parse(scriptLine, info, Boolean.class, matcher.group(1));
 			if (conditional == null) return null;
 
 			NestedRoutine.paddedLogRecord(OutputPreset.INFO, "While: " + conditional);

--- a/src/com/ModDamage/Routines/Nested/With.java
+++ b/src/com/ModDamage/Routines/Nested/With.java
@@ -74,7 +74,7 @@ public class With extends NestedRoutine
 
 			do {
 
-				IDataProvider<?> dp = DataProvider.parse(info, null, sm.spawn(), false, true, asPattern);
+				IDataProvider<?> dp = DataProvider.parse(scriptLine, info, null, sm.spawn(), false, true, asPattern);
 				if (dp == null) return null;
 
 				Matcher m = sm.matchFront(asPattern);

--- a/src/com/ModDamage/Routines/PlayEffect.java
+++ b/src/com/ModDamage/Routines/PlayEffect.java
@@ -85,7 +85,7 @@ public class PlayEffect extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{ 
-			IDataProvider<Location> locDP = DataProvider.parse(info, Location.class, matcher.group(1));
+			IDataProvider<Location> locDP = DataProvider.parse(scriptLine, info, Location.class, matcher.group(1));
 			if (locDP == null) return null;
 			
 			EffectType effectType;
@@ -105,7 +105,7 @@ public class PlayEffect extends Routine
 				Integer ndata = effectType.dataForExtra(matcher.group(3));
 				if (ndata == null)
 				{
-					data = DataProvider.parse(info, Integer.class, matcher.group(3));
+					data = DataProvider.parse(scriptLine, info, Integer.class, matcher.group(3));
 					
 					if (data == null)
 					{
@@ -120,7 +120,7 @@ public class PlayEffect extends Routine
 			IDataProvider<Integer> radius = null;
 			if (matcher.group(4) != null)
 			{
-				radius = DataProvider.parse(info, Integer.class, matcher.group(4));
+				radius = DataProvider.parse(scriptLine, info, Integer.class, matcher.group(4));
 				if (radius == null)
 				{
 					LogUtil.error("Unable to match expression: \""+matcher.group(4)+"\"");

--- a/src/com/ModDamage/Routines/PlayEntityEffect.java
+++ b/src/com/ModDamage/Routines/PlayEntityEffect.java
@@ -44,7 +44,7 @@ public class PlayEntityEffect extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			IDataProvider<Entity> entityDP = DataProvider.parse(info, Entity.class, matcher.group(1));
+			IDataProvider<Entity> entityDP = DataProvider.parse(scriptLine, info, Entity.class, matcher.group(1));
 			if (entityDP == null) return null;
 			
 			EntityEffect effectType;
@@ -54,7 +54,7 @@ public class PlayEntityEffect extends Routine
 			}
 			catch (IllegalArgumentException e)
 			{
-				LogUtil.error("Bad effect type: \""+matcher.group(2)+"\"");
+				LogUtil.error(scriptLine, "Bad effect type: \""+matcher.group(2)+"\"");
 				return null;
 			}
 			

--- a/src/com/ModDamage/Routines/RemovePotionEffect.java
+++ b/src/com/ModDamage/Routines/RemovePotionEffect.java
@@ -45,7 +45,7 @@ public class RemovePotionEffect extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{ 
-			IDataProvider<LivingEntity> livingDP = DataProvider.parse(info, LivingEntity.class, matcher.group(1));
+			IDataProvider<LivingEntity> livingDP = DataProvider.parse(scriptLine, info, LivingEntity.class, matcher.group(1));
 			if (livingDP == null) return null;
 			
 			PotionEffectType type = PotionEffectType.getByName(matcher.group(2).toUpperCase());

--- a/src/com/ModDamage/Routines/RepeatControl.java
+++ b/src/com/ModDamage/Routines/RepeatControl.java
@@ -71,13 +71,13 @@ public class RepeatControl extends Routine
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
 			@SuppressWarnings("rawtypes")
-			IDataProvider itDP = DataProvider.parse(info, Entity.class, matcher.group(1), true, false);
+			IDataProvider itDP = DataProvider.parse(scriptLine, info, Entity.class, matcher.group(1), true, false);
 			if (itDP == null)
-				itDP = DataProvider.parse(info, Location.class, matcher.group(1), true, false);
+				itDP = DataProvider.parse(scriptLine, info, Location.class, matcher.group(1), true, false);
 			if (itDP == null)
-				itDP = DataProvider.parse(info, Chunk.class, matcher.group(1), true, false);
+				itDP = DataProvider.parse(scriptLine, info, Chunk.class, matcher.group(1), true, false);
 			if (itDP == null)
-				itDP = DataProvider.parse(info, World.class, matcher.group(1), true, false);
+				itDP = DataProvider.parse(scriptLine, info, World.class, matcher.group(1), true, false);
 			if (itDP == null) return null;
 			
 			IDataProvider<? extends Number> delay, count;
@@ -89,7 +89,7 @@ public class RepeatControl extends Routine
 				repeatName = matcher.group(4);
 				if (repeatName == null)
 				{
-					LogUtil.error("No repeat name?");
+					LogUtil.error(scriptLine, "No repeat name?");
 					return null;
 				}
 				
@@ -99,10 +99,10 @@ public class RepeatControl extends Routine
 			else
 			{
 				StringMatcher sm = new StringMatcher(matcher.group(3));
-				delay = DataProvider.parse(info, Integer.class, sm.spawn()); if (delay == null) return null;
+				delay = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn()); if (delay == null) return null;
 				if (sm.matchesFront(dotPattern))
 				{
-					count = DataProvider.parse(info, Integer.class, sm.spawn()); if (count == null) return null;
+					count = DataProvider.parse(scriptLine, info, Integer.class, sm.spawn()); if (count == null) return null;
 				}
 				else
 					count = new LiteralNumber(-1);

--- a/src/com/ModDamage/Routines/Routine.java
+++ b/src/com/ModDamage/Routines/Routine.java
@@ -91,7 +91,7 @@ abstract public class Routine
 					return builder;
 			}
 		}
-		LogUtil.error(" No match found for routine \"" + line.line + "\"");
+		LogUtil.error(line, " No match found for routine \"" + line.line + "\"");
 		return null;
 	}
 

--- a/src/com/ModDamage/Routines/SetProperty.java
+++ b/src/com/ModDamage/Routines/SetProperty.java
@@ -50,10 +50,10 @@ public class SetProperty extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{
-			final ISettableDataProvider propertyDP = SettableDataProvider.parse(info, null, matcher.group(1));
+			final ISettableDataProvider propertyDP = SettableDataProvider.parse(scriptLine, info, null, matcher.group(1));
 			if (propertyDP == null) return null;
 			if (!propertyDP.isSettable()) {
-				LogUtil.error("Error: Variable \"" + propertyDP + "\" is read-only.");
+				LogUtil.error(scriptLine, "Error: Variable \"" + propertyDP + "\" is read-only.");
 				return null;
 			}
 
@@ -101,7 +101,7 @@ public class SetProperty extends Routine
 					};
 				else {
 					@SuppressWarnings("unchecked")
-					IDataProvider<Number> newValueDP = DataProvider.parse(info, propertyDP.provides(), value);
+					IDataProvider<Number> newValueDP = DataProvider.parse(scriptLine, info, propertyDP.provides(), value);
 					if (newValueDP == null) return null;
 					valueDP = newValueDP;
 				}

--- a/src/com/ModDamage/Routines/Teleport.java
+++ b/src/com/ModDamage/Routines/Teleport.java
@@ -69,21 +69,21 @@ public class Teleport extends Routine
 		@Override
 		public IRoutineBuilder getNew(Matcher matcher, ScriptLine scriptLine, EventInfo info)
 		{ 
-			IDataProvider<Entity> entityDP = DataProvider.parse(info, Entity.class, matcher.group(1));
+			IDataProvider<Entity> entityDP = DataProvider.parse(scriptLine, info, Entity.class, matcher.group(1));
 			if (entityDP == null) return null;
 			
 			StringMatcher sm = new StringMatcher(matcher.group(2));
 			
 			IDataProvider<Location> locDP;
-            locDP = DataProvider.parse(info, Location.class, sm.spawn()); if (locDP == null) return null;
+            locDP = DataProvider.parse(scriptLine, info, Location.class, sm.spawn()); if (locDP == null) return null;
 			
 			IDataProvider<Number> yaw = null, pitch = null;
 			String yaw_pitch = "";
 			if (!sm.isEmpty()) {
 				if (!sm.matchesFront(dotPattern)) return null;
-				yaw = DataProvider.parse(info, Number.class, sm.spawn()); if (yaw == null) return null;
+				yaw = DataProvider.parse(scriptLine, info, Number.class, sm.spawn()); if (yaw == null) return null;
 				if (!sm.matchesFront(dotPattern)) return null;
-				pitch = DataProvider.parse(info, Number.class, sm.spawn()); if (pitch == null) return null;
+				pitch = DataProvider.parse(scriptLine, info, Number.class, sm.spawn()); if (pitch == null) return null;
 				
 				if (!sm.isEmpty()) return null;
 				

--- a/src/com/ModDamage/Routines/Untag.java
+++ b/src/com/ModDamage/Routines/Untag.java
@@ -48,12 +48,12 @@ public class Untag<T, D> extends Routine
 		{
             StringMatcher sm = new StringMatcher(matcher.group(2));
             
-            Taggable<?> taggable = Taggable.get(DataProvider.parse(info, null, sm.spawn()), info);
+            Taggable<?> taggable = Taggable.get(DataProvider.parse(scriptLine, info, null, sm.spawn()), info);
             if (taggable == null) return null;
             
             if (!sm.matchesFront(dotPattern)) return null;
             
-            IDataProvider<String> tagNameDP = InterpolatedString.parseWord(InterpolatedString.word, sm.spawn(), info);
+            IDataProvider<String> tagNameDP = InterpolatedString.parseWord(scriptLine, InterpolatedString.word, sm.spawn(), info);
             if (tagNameDP == null) return null;
             
             if (!sm.isEmpty()) return null;

--- a/src/com/ModDamage/Variables/Number/EnchantmentInt.java
+++ b/src/com/ModDamage/Variables/Number/EnchantmentInt.java
@@ -12,6 +12,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
 import com.ModDamage.Backend.EnchantmentsRef;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.SettableIntegerExp;
@@ -23,19 +24,19 @@ public class EnchantmentInt extends SettableIntegerExp<EnchantmentsRef>
 		DataProvider.register(Integer.class, Pattern.compile("enchant(?:ment)?_?level_(\\w+)", Pattern.CASE_INSENSITIVE), new BaseDataParser<Integer>()
 				{
 					@Override
-					public IDataProvider<Integer> parse(EventInfo info, Matcher m, StringMatcher sm)
+					public IDataProvider<Integer> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 					{
 						IDataProvider<EnchantmentsRef> enchantmentsDP = info.get(EnchantmentsRef.class, "enchantments", false);
 						if (enchantmentsDP == null)
 						{
-							LogUtil.error("You can only use '"+m.group()+"' inside of an Enchant or PrepareEnchant event");
+							LogUtil.error(scriptLine, "You can only use '"+m.group()+"' inside of an Enchant or PrepareEnchant event");
 							return null;
 						}
 						
 						Enchantment enchantment = Enchantment.getByName(m.group(1).toUpperCase());
 						if (enchantment == null)
 						{
-							LogUtil.error("Unknown enchantment named \"" + m.group(1) + "\"");
+							LogUtil.error(scriptLine, "Unknown enchantment named \"" + m.group(1) + "\"");
 							return null;
 						}
 						return sm.acceptIf(new EnchantmentInt(

--- a/src/com/ModDamage/Variables/Number/ItemEnchantmentInt.java
+++ b/src/com/ModDamage/Variables/Number/ItemEnchantmentInt.java
@@ -9,6 +9,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
 import com.ModDamage.Backend.ItemHolder;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.SettableIntegerExp;
@@ -23,12 +24,12 @@ public class ItemEnchantmentInt extends SettableIntegerExp<ItemHolder>
 		DataProvider.register(Integer.class, ItemHolder.class, Pattern.compile("_enchant(?:ment)?_?level_(\\w+)", Pattern.CASE_INSENSITIVE), new IDataParser<Integer, ItemHolder>()
 				{
 					@Override
-					public IDataProvider<Integer> parse(EventInfo info, IDataProvider<ItemHolder> itemDP, Matcher m, StringMatcher sm)
+					public IDataProvider<Integer> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<ItemHolder> itemDP, Matcher m, StringMatcher sm)
 					{
 						Enchantment enchantment = Enchantment.getByName(m.group(1).toUpperCase());
 						if (enchantment == null)
 						{
-							LogUtil.error("Unknown enchantment named \"" + m.group(1) + "\"");
+							LogUtil.error(scriptLine, "Unknown enchantment named \"" + m.group(1) + "\"");
 							return null;
 						}
 						return sm.acceptIf(new ItemEnchantmentInt(

--- a/src/com/ModDamage/Variables/Number/LocalNum.java
+++ b/src/com/ModDamage/Variables/Number/LocalNum.java
@@ -4,6 +4,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.ModDamage.StringMatcher;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
 import com.ModDamage.Parsing.DataProvider;
@@ -16,7 +17,7 @@ public class LocalNum
 		DataProvider.register(Number.class, null, Pattern.compile("\\$(\\w+)", Pattern.CASE_INSENSITIVE), new BaseDataParser<Number>()
 				{
 					@Override
-					public IDataProvider<Number> parse(EventInfo info, Matcher m, StringMatcher sm)
+					public IDataProvider<Number> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 					{
 						return info.getLocal(m.group(1).toLowerCase());
 					}

--- a/src/com/ModDamage/Variables/Number/NegativeNum.java
+++ b/src/com/ModDamage/Variables/Number/NegativeNum.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Parsing.BaseDataParser;
@@ -19,9 +20,9 @@ public class NegativeNum implements IDataProvider<Number>
 		DataProvider.register(Number.class, Pattern.compile("-"), new BaseDataParser<Number>()
 				{
 					@Override
-					public IDataProvider<Number> parse(EventInfo info, Matcher m, StringMatcher sm)
+					public IDataProvider<Number> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 					{
-						IDataProvider<Number> number = DataProvider.parse(info, Number.class, sm.spawn());
+						IDataProvider<Number> number = DataProvider.parse(scriptLine, info, Number.class, sm.spawn());
 						if (number == null) return null;
 						
 						return sm.acceptIf(new NegativeNum(number));

--- a/src/com/ModDamage/Variables/Number/NumberOp.java
+++ b/src/com/ModDamage/Variables/Number/NumberOp.java
@@ -12,6 +12,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.NumberExp;
@@ -117,14 +118,14 @@ public class NumberOp extends NumberExp<Number>
 		DataProvider.register(Number.class, Number.class, Operator.operatorPattern, new IDataParser<Number, Number>()
 				{
 					@Override
-					public IDataProvider<Number> parse(EventInfo info, IDataProvider<Number> leftDP, Matcher m, StringMatcher sm)
+					public IDataProvider<Number> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Number> leftDP, Matcher m, StringMatcher sm)
 					{
 						Operator operator = Operator.operatorMap.get(m.group(1));
 						
-						IDataProvider<Number> rightDP = DataProvider.parse(info, Number.class, sm.spawn());
+						IDataProvider<Number> rightDP = DataProvider.parse(scriptLine, info, Number.class, sm.spawn());
 						if (rightDP == null)
 						{
-							LogUtil.error("Unable to match expression: \""+sm.string+"\"");
+							LogUtil.error(scriptLine, "Unable to match expression: \""+sm.string+"\"");
 							return null;
 						}
 						

--- a/src/com/ModDamage/Variables/Number/PotionEffectInt.java
+++ b/src/com/ModDamage/Variables/Number/PotionEffectInt.java
@@ -14,6 +14,7 @@ import com.ModDamage.LogUtil;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.NumberExp;
@@ -47,12 +48,12 @@ public class PotionEffectInt extends NumberExp<LivingEntity>
 				new IDataParser<Number, LivingEntity>()
 				{
 					@Override
-					public IDataProvider<Number> parse(EventInfo info, IDataProvider<LivingEntity> livingDP, Matcher m, StringMatcher sm)
+					public IDataProvider<Number> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<LivingEntity> livingDP, Matcher m, StringMatcher sm)
 					{
 						PotionEffectType type = PotionEffectType.getByName(m.group(1).toUpperCase());
 						if (type == null)
 						{
-							LogUtil.error("Unknown potion effect type '"+m.group(1)+"'");
+							LogUtil.error(scriptLine, "Unknown potion effect type '"+m.group(1)+"'");
 							return null;
 						}
 						

--- a/src/com/ModDamage/Variables/PlayerNamed.java
+++ b/src/com/ModDamage/Variables/PlayerNamed.java
@@ -8,6 +8,7 @@ import org.bukkit.OfflinePlayer;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.InterpolatedString;
@@ -26,9 +27,9 @@ public class PlayerNamed implements IDataProvider<OfflinePlayer>
 				new BaseDataParser<OfflinePlayer>()
 				{
 					@Override
-					public IDataProvider<OfflinePlayer> parse(EventInfo info, Matcher m, StringMatcher sm)
+					public IDataProvider<OfflinePlayer> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 					{
-                        IDataProvider<String> name = InterpolatedString.parseWord(word, sm.spawn(), info);
+                        IDataProvider<String> name = InterpolatedString.parseWord(scriptLine, word, sm.spawn(), info);
                         if (name == null) return null;
 
                         sm.accept();

--- a/src/com/ModDamage/Variables/ScoreboardNamed.java
+++ b/src/com/ModDamage/Variables/ScoreboardNamed.java
@@ -8,6 +8,7 @@ import org.bukkit.scoreboard.Scoreboard;
 import com.ModDamage.Scoreboards;
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.InterpolatedString;
@@ -26,9 +27,9 @@ public class ScoreboardNamed implements IDataProvider<Scoreboard>
 				new BaseDataParser<Scoreboard>()
 				{
 					@Override
-					public IDataProvider<Scoreboard> parse(EventInfo info, Matcher m, StringMatcher sm)
+					public IDataProvider<Scoreboard> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 					{
-                        IDataProvider<String> nameDP = InterpolatedString.parseWord(word, sm.spawn(), info);
+                        IDataProvider<String> nameDP = InterpolatedString.parseWord(scriptLine, word, sm.spawn(), info);
                         if (nameDP == null) return null;
 
                         sm.accept();

--- a/src/com/ModDamage/Variables/String/EntityString.java
+++ b/src/com/ModDamage/Variables/String/EntityString.java
@@ -10,6 +10,7 @@ import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Alias.TypeNameAliaser;
 import com.ModDamage.Backend.ExternalPluginManager;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.StringExp;
@@ -76,7 +77,7 @@ public class EntityString extends StringExp<Entity>
 		DataProvider.register(String.class, Entity.class, pattern, new IDataParser<String, Entity>()
 			{
 				@Override
-				public IDataProvider<String> parse(EventInfo info, IDataProvider<Entity> entityDP, Matcher m, StringMatcher sm)
+				public IDataProvider<String> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Entity> entityDP, Matcher m, StringMatcher sm)
 				{
 					return new EntityString(entityDP, EntityStringProperty.valueOf(m.group(1).toUpperCase()));
 				}

--- a/src/com/ModDamage/Variables/String/PlayerString.java
+++ b/src/com/ModDamage/Variables/String/PlayerString.java
@@ -9,6 +9,7 @@ import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
 import com.ModDamage.Backend.ArmorSet;
 import com.ModDamage.Backend.ExternalPluginManager;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.StringExp;
@@ -119,7 +120,7 @@ public class PlayerString extends StringExp<Player>
 		DataProvider.register(String.class, Player.class, pattern, new IDataParser<String, Player>()
 			{
 				@Override
-				public IDataProvider<String> parse(EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
+				public IDataProvider<String> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Player> playerDP, Matcher m, StringMatcher sm)
 				{
 					sm.accept();
 					return new PlayerString(playerDP, PlayerStringProperty.valueOf(m.group(1).toUpperCase()));

--- a/src/com/ModDamage/Variables/String/WorldString.java
+++ b/src/com/ModDamage/Variables/String/WorldString.java
@@ -7,6 +7,7 @@ import org.bukkit.World;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Utils;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.StringExp;
@@ -59,7 +60,7 @@ public class WorldString extends StringExp<World>
 		DataProvider.register(String.class, World.class, pattern, new IDataParser<String, World>()
 			{
 				@Override
-				public IDataProvider<String> parse(EventInfo info, IDataProvider<World> worldDP, Matcher m, StringMatcher sm)
+				public IDataProvider<String> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<World> worldDP, Matcher m, StringMatcher sm)
 				{
 					return new WorldString(worldDP, WorldStringProperty.valueOf(m.group(1).toUpperCase()));
 				}

--- a/src/com/ModDamage/Variables/TagValue.java
+++ b/src/com/ModDamage/Variables/TagValue.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.InterpolatedString;
@@ -24,9 +25,9 @@ public class TagValue<T, S> extends SettableDataProvider<T, S>
 				{
 					@Override
                     @SuppressWarnings({ "unchecked", "rawtypes" })
-					public IDataProvider<Object> parse(EventInfo info, IDataProvider<Object> objDP, Matcher m, StringMatcher sm)
+					public IDataProvider<Object> parse(ScriptLine scriptLine, EventInfo info, IDataProvider<Object> objDP, Matcher m, StringMatcher sm)
 					{
-                        Tag<?> tag = Tag.get(InterpolatedString.parseWord(InterpolatedString.word, sm.spawn(), info), m.group(1));
+                        Tag<?> tag = Tag.get(InterpolatedString.parseWord(scriptLine, InterpolatedString.word, sm.spawn(), info), m.group(1));
                         if (tag == null) return null;
 
                         Taggable<?> taggable = Taggable.get(objDP, info);

--- a/src/com/ModDamage/Variables/WorldNamed.java
+++ b/src/com/ModDamage/Variables/WorldNamed.java
@@ -8,6 +8,7 @@ import org.bukkit.World;
 
 import com.ModDamage.StringMatcher;
 import com.ModDamage.Backend.BailException;
+import com.ModDamage.Backend.ScriptLine;
 import com.ModDamage.EventInfo.EventData;
 import com.ModDamage.EventInfo.EventInfo;
 import com.ModDamage.Expressions.InterpolatedString;
@@ -24,9 +25,9 @@ public class WorldNamed implements IDataProvider<World>
 				new BaseDataParser<World>()
 				{
 					@Override
-					public IDataProvider<World> parse(EventInfo info, Matcher m, StringMatcher sm)
+					public IDataProvider<World> parse(ScriptLine scriptLine, EventInfo info, Matcher m, StringMatcher sm)
 					{
-                        IDataProvider<String> name = InterpolatedString.parseWord(InterpolatedString.word, sm.spawn(), info);
+                        IDataProvider<String> name = InterpolatedString.parseWord(scriptLine, InterpolatedString.word, sm.spawn(), info);
                         if (name == null) return null;
 
                         sm.accept();


### PR DESCRIPTION
This will make it easier to debug larger configs.

Do note that the log formatting is a little less neat from it now. This might need cleaning in future but its ok for what was needed.

The messed up part of log formatting is only the fact that the line numbers are placed in a spot that would make lines not unified if read side by side along a verbose output (Showing each line of config) but this doe snot matter since Its actually easier to spot out an error this way.

I TALKED TO MUCH GAH!
